### PR TITLE
Loadout fixes lost in the repo move

### DIFF
--- a/code/datums/greyscale/json_configs/plushie_lizard.json
+++ b/code/datums/greyscale/json_configs/plushie_lizard.json
@@ -1,5 +1,5 @@
 {
-	"": [
+	"map_plushie_lizard": [
 		{
 			"type": "icon_state",
 			"icon_state": "plushie_lizard_body",

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -502,7 +502,7 @@
 /obj/item/toy/plush/lizard_plushie
 	name = "lizard plushie"
 	desc = "An adorable stuffed toy that resembles a lizardperson."
-	icon_state = "map_pushie_lizard"
+	icon_state = "map_plushie_lizard" // NON-MODULE CHANGE
 	greyscale_config = /datum/greyscale_config/plush_lizard
 	attack_verb_continuous = list("claws", "hisses", "tail slaps")
 	attack_verb_simple = list("claw", "hiss", "tail slap")

--- a/jollystation_modules/README.md
+++ b/jollystation_modules/README.md
@@ -102,11 +102,13 @@ To prevent me from accidentally accept incoming on files with module changes, I'
 - code\datums\datacore.dm
 - code\datums\id_trim\jobs.dm
 - code\datums\mapgen\Cavegens\LavalandGenerator.dm
+- code\datums\greyscale\json_configs\plushie_lizard.json
 - code\game\gamemodes\objective_items.dm
 - code\game\machinery\computer\crew.dm
 - code\game\machinery\computer\medical.dm
 - code\game\machinery\computer\security.dm
 - code\game\objects\items\implants\implantuplink.dm
+- code\game\objects\items\plushes.dm
 - code\modules\antagonists\eldritch_cult\eldritch_effects.dm
 - code\modules\antagonists\eldritch_cult\eldritch_knowledge.dm
 - code\modules\antagonists\traitor\datum_traitor.dm

--- a/jollystation_modules/code/modules/client/loadout_manager.dm
+++ b/jollystation_modules/code/modules/client/loadout_manager.dm
@@ -142,7 +142,7 @@
 /// Select [path] item to [category_slot] slot, and open up the greyscale UI to customize [path] in [category] slot.
 /datum/loadout_manager/proc/select_item_color(path, category_slot)
 	if(menu)
-		to_chat(owner, "<span class='warning'>You already have a greyscaling window open!</span>")
+		to_chat(owner, span_warning("You already have a greyscaling window open!"))
 		return
 
 	var/obj/item/colored_item = new path
@@ -163,6 +163,11 @@
 	var/slot_starting_colors = colored_item.greyscale_colors
 	if(owner.prefs.greyscale_loadout_list && owner.prefs.greyscale_loadout_list[category_slot])
 		slot_starting_colors = owner.prefs.greyscale_loadout_list[category_slot]
+
+	var/datum/greyscale_config/current_config = SSgreyscale.configurations[colored_item.greyscale_config]
+	if(current_config && !current_config.icon_states)
+		to_chat(owner, span_warning("This item isn't properly configured for greyscaling! Complain to a coder!"))
+		CRASH("Loadout manager attempted to pass greyscale item without icon_states into greyscale modification menu!")
 
 	menu = new(
 		src,
@@ -187,12 +192,12 @@
 /// Sets [category_slot]'s greyscale colors to the colors in the currently opened [open_menu].
 /datum/loadout_manager/proc/set_slot_greyscale(category_slot, datum/greyscale_modify_menu/open_menu)
 	if(!open_menu)
-		CRASH("set_slot_greyscale called without a greyscale menu")
+		CRASH("set_slot_greyscale called without a greyscale menu!")
 
 	var/list/loadout = owner.prefs.loadout_list
 
 	if(!loadout[category_slot])
-		to_chat(owner, "<span class='warning'>Select the item before attempting to apply greyscale to it!</span>")
+		to_chat(owner, span_warning("Select the item before attempting to apply greyscale to it!"))
 		return
 
 	var/list/colors = open_menu.split_colors

--- a/tgui/packages/tgui/index.js
+++ b/tgui/packages/tgui/index.js
@@ -17,6 +17,8 @@ import './styles/themes/retro.scss';
 import './styles/themes/syndicate.scss';
 import './styles/themes/wizard.scss';
 
+import './styles/themes/jolly-syndicate.scss'; // NON-MODULE CHANGE
+
 import { perf } from 'common/perf';
 import { setupHotReloading } from 'tgui-dev-server/link/client';
 import { setupHotKeys } from './hotkeys';


### PR DESCRIPTION
I fixed this in the past, but at some point between the upstream merge and repo move it was unfixed.

Same fix, also some added sanity so it fail less silently.