### PR TITLE
Adds in the Berry Physics and NERVA Outpost space ruins.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/jolly_berry.dmm
+++ b/_maps/RandomRuins/SpaceRuins/jolly_berry.dmm
@@ -67,7 +67,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/powered/berry_physics)
 "M" = (
-/turf/closed/wall/mineral/uranium,
+/turf/closed/indestructible/riveted/uranium,
 /area/ruin/space/has_grav/powered/berry_physics)
 "O" = (
 /obj/structure/table/bronze,

--- a/_maps/RandomRuins/SpaceRuins/jolly_berry.dmm
+++ b/_maps/RandomRuins/SpaceRuins/jolly_berry.dmm
@@ -1,23 +1,180 @@
-"a" = (/obj/machinery/light/small/red/directional{dir = 1},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
-"d" = (/obj/structure/table/bronze,/obj/item/seeds/berry{potency = 100},/obj/item/seeds/berry/glow{potency = 100},/obj/item/seeds/berry/glow{potency = 100},/obj/item/seeds/berry/glow{potency = 100},/obj/item/seeds/berry{potency = 100},/obj/item/seeds/berry{potency = 100},/obj/item/seeds/berry{potency = 100},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
-"h" = (/obj/structure/table/bronze,/obj/item/seeds/berry/glow{name = "Berrynger of Light"; pixel_x = -10; pixel_y = 10; potency = 100},/obj/item/seeds/berry/poison{name = "Berrynger of Poison"; pixel_x = 10; pixel_y = 10; potency = 100},/obj/item/seeds/berry/death{name = "Berrynger of Death"; pixel_y = -10; potency = 100},/obj/item/circuitboard/machine/protolathe{desc = "It looks covered in jam."; name = "Berry-Infused Protolathe (Machine Board)"},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
-"j" = (/obj/item/gps/spaceruin,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/powered/berry_physics)
-"q" = (/obj/machinery/door/airlock/external/glass,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
-"J" = (/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
-"M" = (/turf/closed/wall/mineral/uranium,/area/ruin/space/has_grav/powered/berry_physics)
-"O" = (/obj/structure/table/bronze,/obj/item/seeds/berry/death{potency = 100},/obj/item/seeds/berry/death{potency = 100},/obj/item/seeds/berry/death{potency = 100},/obj/item/seeds/berry/poison{potency = 100},/obj/item/seeds/berry/poison{potency = 100},/obj/item/seeds/berry/poison{potency = 100},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
-"Q" = (/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/powered/berry_physics)
-"S" = (/turf/closed/wall/mineral/plastitanium/nodiagonal,/area/ruin/space/has_grav/powered/berry_physics)
-"X" = (/turf/template_noop,/area/template_noop)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/light/small/red/directional{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/powered/berry_physics)
+"d" = (
+/obj/structure/table/bronze,
+/obj/item/seeds/berry{
+	potency = 100
+	},
+/obj/item/seeds/berry/glow{
+	potency = 100
+	},
+/obj/item/seeds/berry/glow{
+	potency = 100
+	},
+/obj/item/seeds/berry/glow{
+	potency = 100
+	},
+/obj/item/seeds/berry{
+	potency = 100
+	},
+/obj/item/seeds/berry{
+	potency = 100
+	},
+/obj/item/seeds/berry{
+	potency = 100
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/powered/berry_physics)
+"h" = (
+/obj/structure/table/bronze,
+/obj/item/seeds/berry/glow{
+	name = "Berrynger of Light";
+	pixel_x = -10;
+	pixel_y = 10;
+	potency = 100
+	},
+/obj/item/seeds/berry/poison{
+	name = "Berrynger of Poison";
+	pixel_x = 10;
+	pixel_y = 10;
+	potency = 100
+	},
+/obj/item/seeds/berry/death{
+	name = "Berrynger of Death";
+	pixel_y = -10;
+	potency = 100
+	},
+/obj/item/circuitboard/machine/protolathe{
+	desc = "It looks covered in jam.";
+	name = "Berry-Infused Protolathe (Machine Board)"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/powered/berry_physics)
+"j" = (
+/obj/item/gps/spaceruin,
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/powered/berry_physics)
+"q" = (
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/powered/berry_physics)
+"J" = (
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/powered/berry_physics)
+"M" = (
+/turf/closed/wall/mineral/uranium,
+/area/ruin/space/has_grav/powered/berry_physics)
+"O" = (
+/obj/structure/table/bronze,
+/obj/item/seeds/berry/death{
+	potency = 100
+	},
+/obj/item/seeds/berry/death{
+	potency = 100
+	},
+/obj/item/seeds/berry/death{
+	potency = 100
+	},
+/obj/item/seeds/berry/poison{
+	potency = 100
+	},
+/obj/item/seeds/berry/poison{
+	potency = 100
+	},
+/obj/item/seeds/berry/poison{
+	potency = 100
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/ruin/space/has_grav/powered/berry_physics)
+"Q" = (
+/turf/open/floor/mineral/plastitanium/red,
+/area/ruin/space/has_grav/powered/berry_physics)
+"S" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/ruin/space/has_grav/powered/berry_physics)
+"X" = (
+/turf/template_noop,
+/area/template_noop)
 
 (1,1,1) = {"
-MMXXXMM
-MSMXMSM
-XMSSSMX
-XSShSSX
-SjaQaQS
-SdQJQOS
-SQJQJQS
-XSQJQSX
-XXSqSXX
+M
+M
+X
+X
+S
+S
+S
+X
+X
+"}
+(2,1,1) = {"
+M
+S
+M
+S
+j
+d
+Q
+S
+X
+"}
+(3,1,1) = {"
+X
+M
+S
+S
+a
+Q
+J
+Q
+S
+"}
+(4,1,1) = {"
+X
+X
+S
+h
+Q
+J
+Q
+J
+q
+"}
+(5,1,1) = {"
+X
+M
+S
+S
+a
+Q
+J
+Q
+S
+"}
+(6,1,1) = {"
+M
+S
+M
+S
+Q
+O
+Q
+S
+X
+"}
+(7,1,1) = {"
+M
+M
+X
+X
+S
+S
+S
+X
+X
 "}

--- a/_maps/RandomRuins/SpaceRuins/jolly_berry.dmm
+++ b/_maps/RandomRuins/SpaceRuins/jolly_berry.dmm
@@ -1,0 +1,23 @@
+"a" = (/obj/machinery/light/small/red/directional{dir = 1},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
+"d" = (/obj/structure/table/bronze,/obj/item/seeds/berry{potency = 100},/obj/item/seeds/berry/glow{potency = 100},/obj/item/seeds/berry/glow{potency = 100},/obj/item/seeds/berry/glow{potency = 100},/obj/item/seeds/berry{potency = 100},/obj/item/seeds/berry{potency = 100},/obj/item/seeds/berry{potency = 100},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
+"h" = (/obj/structure/table/bronze,/obj/item/seeds/berry/glow{name = "Berrynger of Light"; pixel_x = -10; pixel_y = 10; potency = 100},/obj/item/seeds/berry/poison{name = "Berrynger of Poison"; pixel_x = 10; pixel_y = 10; potency = 100},/obj/item/seeds/berry/death{name = "Berrynger of Death"; pixel_y = -10; potency = 100},/obj/item/circuitboard/machine/protolathe{desc = "It looks covered in jam."; name = "Berry-Infused Protolathe (Machine Board)"},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
+"j" = (/obj/item/gps/spaceruin,/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/powered/berry_physics)
+"q" = (/obj/machinery/door/airlock/external/glass,/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
+"J" = (/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
+"M" = (/turf/closed/wall/mineral/uranium,/area/ruin/space/has_grav/powered/berry_physics)
+"O" = (/obj/structure/table/bronze,/obj/item/seeds/berry/death{potency = 100},/obj/item/seeds/berry/death{potency = 100},/obj/item/seeds/berry/death{potency = 100},/obj/item/seeds/berry/poison{potency = 100},/obj/item/seeds/berry/poison{potency = 100},/obj/item/seeds/berry/poison{potency = 100},/turf/open/floor/mineral/plastitanium,/area/ruin/space/has_grav/powered/berry_physics)
+"Q" = (/turf/open/floor/mineral/plastitanium/red,/area/ruin/space/has_grav/powered/berry_physics)
+"S" = (/turf/closed/wall/mineral/plastitanium/nodiagonal,/area/ruin/space/has_grav/powered/berry_physics)
+"X" = (/turf/template_noop,/area/template_noop)
+
+(1,1,1) = {"
+MMXXXMM
+MSMXMSM
+XMSSSMX
+XSShSSX
+SjaQaQS
+SdQJQOS
+SQJQJQS
+XSQJQSX
+XXSqSXX
+"}

--- a/_maps/RandomRuins/SpaceRuins/jolly_nerva.dmm
+++ b/_maps/RandomRuins/SpaceRuins/jolly_nerva.dmm
@@ -1,100 +1,848 @@
-"ah" = (/obj/machinery/power/tracker,/obj/structure/cable,/turf/open/floor/iron/solarpanel/airless,/area/solars/nerva)
-"bq" = (/obj/structure/lattice/catwalk,/obj/machinery/atmospherics/components/unary/outlet_injector/layer2,/turf/template_noop,/area/ruin/space/has_grav/nerva)
-"bs" = (/obj/structure/lattice/catwalk,/obj/item/stack/cable_coil/cut,/turf/template_noop,/area/solars/nerva)
-"bG" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
-"cc" = (/turf/open/floor/iron/dark/corner{dir = 8},/area/ruin/space/has_grav/nerva)
-"cg" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
-"et" = (/obj/item/food/deadmouse{desc = "Poor fella."; name = "\proper Tom the Space Mouse"},/turf/template_noop,/area/template_noop)
-"eE" = (/obj/effect/turf_decal/tile/purple{dir = 1},/obj/effect/turf_decal/tile/purple{dir = 4},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"fw" = (/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 4},/obj/machinery/door/airlock/external/glass,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
-"fy" = (/obj/structure/cable,/obj/machinery/door/airlock/external/glass,/obj/effect/mapping_helpers/airlock/cyclelink_helper,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
-"fP" = (/turf/open/floor/iron/dark/corner,/area/ruin/space/has_grav/nerva)
-"gp" = (/obj/effect/turf_decal/tile/purple{dir = 4},/turf/open/floor/iron/corner{dir = 4},/area/ruin/space/has_grav/nerva)
-"gx" = (/obj/effect/turf_decal/tile/purple{dir = 1},/turf/open/floor/iron/corner{dir = 1},/area/ruin/space/has_grav/nerva)
-"gK" = (/obj/structure/cable,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
-"gX" = (/obj/item/gps/spaceruin,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
-"hw" = (/obj/machinery/atmospherics/components/unary/tank/air,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
-"hS" = (/obj/structure/cable,/obj/machinery/power/solar_control,/obj/machinery/light/directional{dir = 1},/turf/open/floor/iron/dark/side{dir = 9},/area/ruin/space/has_grav/nerva)
-"il" = (/obj/machinery/light/directional{dir = 4},/turf/open/floor/iron/dark/side{dir = 6},/area/ruin/space/has_grav/nerva)
-"ji" = (/obj/structure/cable,/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"kv" = (/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 8},/obj/machinery/door/airlock/external/glass,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
-"kI" = (/obj/machinery/light/directional{dir = 8},/turf/open/floor/iron/dark/side{dir = 10},/area/ruin/space/has_grav/nerva)
-"lY" = (/obj/effect/turf_decal/stripes/corner{dir = 8},/turf/open/floor/iron/dark/corner,/area/ruin/space/has_grav/nerva)
-"nd" = (/obj/structure/cable,/obj/machinery/door/airlock/external/glass,/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
-"nu" = (/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 1},/obj/machinery/door/airlock/external/glass,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
-"ox" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
-"pZ" = (/obj/machinery/light/directional,/turf/open/floor/iron/dark/side{dir = 6},/area/ruin/space/has_grav/nerva)
-"re" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/corner{dir = 4},/turf/open/floor/iron/dark/corner{dir = 1},/area/ruin/space/has_grav/nerva)
-"ro" = (/obj/structure/cable,/obj/machinery/power/terminal{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 1},/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
-"vd" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
-"vZ" = (/obj/machinery/airalarm/directional/east,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
-"wl" = (/obj/structure/cable,/obj/machinery/power/smes/engineering{charge = 0},/obj/effect/turf_decal/stripes/corner{dir = 1},/turf/open/floor/iron/dark/corner{dir = 4},/area/ruin/space/has_grav/nerva)
-"xb" = (/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
-"yi" = (/obj/effect/turf_decal/stripes/corner{dir = 4},/turf/open/floor/iron/dark/corner,/area/ruin/space/has_grav/nerva)
-"yG" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/obj/effect/turf_decal/tile/purple{dir = 1},/obj/effect/turf_decal/tile/purple{dir = 8},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"BD" = (/obj/structure/cable,/obj/machinery/power/apc/auto_name/north,/turf/open/floor/iron/dark/side{dir = 5},/area/ruin/space/has_grav/nerva)
-"DE" = (/obj/machinery/light/directional{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
-"ED" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
-"EI" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/corner{dir = 1},/area/ruin/space/has_grav/nerva)
-"Fj" = (/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"FU" = (/obj/effect/turf_decal/stripes/corner,/turf/open/floor/iron/dark/corner{dir = 8},/area/ruin/space/has_grav/nerva)
-"GO" = (/obj/effect/turf_decal/stripes/corner{dir = 1},/turf/open/floor/iron/dark/corner{dir = 8},/area/ruin/space/has_grav/nerva)
-"Hl" = (/obj/machinery/spaceship_navigation_beacon,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/turf/open/floor/iron/smooth_large,/area/ruin/space/has_grav/nerva)
-"Hp" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"HL" = (/obj/structure/lattice/catwalk,/obj/structure/cable,/turf/template_noop,/area/solars/nerva)
-"In" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/obj/effect/turf_decal/tile/purple,/obj/effect/turf_decal/tile/purple{dir = 4},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"Iw" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"Jz" = (/turf/open/floor/iron/corner{dir = 8},/area/ruin/space/has_grav/nerva)
-"Ke" = (/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
-"Kf" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"Kn" = (/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
-"KY" = (/obj/machinery/power/solar,/obj/structure/cable,/turf/open/floor/iron/solarpanel/airless,/area/solars/nerva)
-"LX" = (/obj/machinery/light/directional,/turf/open/floor/iron/dark/side{dir = 10},/area/ruin/space/has_grav/nerva)
-"Nd" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/turf/open/floor/iron/dark/corner{dir = 4},/area/ruin/space/has_grav/nerva)
-"Oh" = (/obj/effect/mapping_helpers/airlock/cyclelink_helper,/obj/machinery/door/airlock/external/glass,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
-"OB" = (/turf/open/floor/iron/dark/side{dir = 9},/area/ruin/space/has_grav/nerva)
-"ON" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"OO" = (/obj/machinery/gravity_generator/main/station,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
-"Py" = (/turf/open/floor/iron/corner{dir = 1},/area/ruin/space/has_grav/nerva)
-"QB" = (/turf/open/floor/iron/corner{dir = 4},/area/ruin/space/has_grav/nerva)
-"Ru" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
-"RD" = (/obj/machinery/light/directional{dir = 4},/turf/open/floor/iron/dark/side{dir = 5},/area/ruin/space/has_grav/nerva)
-"RL" = (/obj/effect/turf_decal/stripes/corner{dir = 8},/turf/open/floor/iron/dark/corner{dir = 1},/area/ruin/space/has_grav/nerva)
-"RS" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"Ul" = (/obj/effect/turf_decal/tile/purple,/obj/effect/turf_decal/tile/purple,/turf/open/floor/iron/corner,/area/ruin/space/has_grav/nerva)
-"Uv" = (/obj/effect/turf_decal/tile/purple,/obj/effect/turf_decal/tile/purple{dir = 8},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"Uw" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
-"UL" = (/obj/effect/turf_decal/tile/purple{dir = 8},/turf/open/floor/iron/corner{dir = 8},/area/ruin/space/has_grav/nerva)
-"Wb" = (/turf/closed/wall/r_wall,/area/ruin/space/has_grav/nerva)
-"YB" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
-"Zj" = (/turf/template_noop,/area/template_noop)
-"Zp" = (/obj/effect/turf_decal/stripes/corner,/turf/open/floor/iron/dark/corner{dir = 4},/area/ruin/space/has_grav/nerva)
-"ZG" = (/turf/open/floor/iron/corner,/area/ruin/space/has_grav/nerva)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"ah" = (
+/obj/machinery/power/tracker,
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel/airless,
+/area/solars/nerva)
+"bq" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/layer2,
+/turf/template_noop,
+/area/ruin/space/has_grav/nerva)
+"bs" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/cable_coil/cut,
+/turf/template_noop,
+/area/solars/nerva)
+"bG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron/large,
+/area/ruin/space/has_grav/nerva)
+"cc" = (
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/nerva)
+"cg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/nerva)
+"et" = (
+/obj/item/food/deadmouse{
+	desc = "Poor fella.";
+	name = "\proper Tom the Space Mouse"
+	},
+/turf/template_noop,
+/area/template_noop)
+"eE" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"fw" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/nerva)
+"fy" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/nerva)
+"fP" = (
+/turf/open/floor/iron/dark/corner,
+/area/ruin/space/has_grav/nerva)
+"gp" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/nerva)
+"gx" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/nerva)
+"gK" = (
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/nerva)
+"gX" = (
+/obj/item/gps/spaceruin,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/nerva)
+"hw" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/nerva)
+"hS" = (
+/obj/structure/cable,
+/obj/machinery/power/solar_control,
+/obj/machinery/light/directional{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/ruin/space/has_grav/nerva)
+"il" = (
+/obj/machinery/light/directional{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/ruin/space/has_grav/nerva)
+"ji" = (
+/obj/structure/cable,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"kv" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/nerva)
+"kI" = (
+/obj/machinery/light/directional{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/ruin/space/has_grav/nerva)
+"lY" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner,
+/area/ruin/space/has_grav/nerva)
+"nd" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/external/glass,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/nerva)
+"nu" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/nerva)
+"ox" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/nerva)
+"pZ" = (
+/obj/machinery/light/directional,
+/turf/open/floor/iron/dark/side{
+	dir = 6
+	},
+/area/ruin/space/has_grav/nerva)
+"re" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/nerva)
+"ro" = (
+/obj/structure/cable,
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/iron/large,
+/area/ruin/space/has_grav/nerva)
+"vd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/large,
+/area/ruin/space/has_grav/nerva)
+"vZ" = (
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/nerva)
+"wl" = (
+/obj/structure/cable,
+/obj/machinery/power/smes/engineering{
+	charge = 0
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/nerva)
+"xb" = (
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/nerva)
+"yi" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/corner,
+/area/ruin/space/has_grav/nerva)
+"yG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"BD" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/north,
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/ruin/space/has_grav/nerva)
+"DE" = (
+/obj/machinery/light/directional{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/nerva)
+"ED" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/nerva)
+"EI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/nerva)
+"Fj" = (
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"FU" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/nerva)
+"GO" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/nerva)
+"Hl" = (
+/obj/machinery/spaceship_navigation_beacon,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth_large,
+/area/ruin/space/has_grav/nerva)
+"Hp" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"HL" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/template_noop,
+/area/solars/nerva)
+"In" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"Iw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"Jz" = (
+/turf/open/floor/iron/corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/nerva)
+"Ke" = (
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/nerva)
+"Kf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"Kn" = (
+/turf/open/floor/iron/large,
+/area/ruin/space/has_grav/nerva)
+"KY" = (
+/obj/machinery/power/solar,
+/obj/structure/cable,
+/turf/open/floor/iron/solarpanel/airless,
+/area/solars/nerva)
+"LX" = (
+/obj/machinery/light/directional,
+/turf/open/floor/iron/dark/side{
+	dir = 10
+	},
+/area/ruin/space/has_grav/nerva)
+"Nd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/nerva)
+"Oh" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/nerva)
+"OB" = (
+/turf/open/floor/iron/dark/side{
+	dir = 9
+	},
+/area/ruin/space/has_grav/nerva)
+"ON" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"OO" = (
+/obj/machinery/gravity_generator/main/station,
+/turf/open/floor/iron/dark,
+/area/ruin/space/has_grav/nerva)
+"Py" = (
+/turf/open/floor/iron/corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/nerva)
+"QB" = (
+/turf/open/floor/iron/corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/nerva)
+"Ru" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/iron/large,
+/area/ruin/space/has_grav/nerva)
+"RD" = (
+/obj/machinery/light/directional{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/side{
+	dir = 5
+	},
+/area/ruin/space/has_grav/nerva)
+"RL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/corner{
+	dir = 1
+	},
+/area/ruin/space/has_grav/nerva)
+"RS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"Ul" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/iron/corner,
+/area/ruin/space/has_grav/nerva)
+"Uv" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"Uw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/large,
+/area/ruin/space/has_grav/nerva)
+"UL" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/iron/corner{
+	dir = 8
+	},
+/area/ruin/space/has_grav/nerva)
+"Wb" = (
+/turf/closed/wall/r_wall,
+/area/ruin/space/has_grav/nerva)
+"YB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron,
+/area/ruin/space/has_grav/nerva)
+"Zj" = (
+/turf/template_noop,
+/area/template_noop)
+"Zp" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/iron/dark/corner{
+	dir = 4
+	},
+/area/ruin/space/has_grav/nerva)
+"ZG" = (
+/turf/open/floor/iron/corner,
+/area/ruin/space/has_grav/nerva)
 
 (1,1,1) = {"
-ZjZjKYKYKYKYKYahKYKYKYKYKYZjZj
-ZjZjHLHLHLHLHLHLHLHLHLHLHLZjZj
-ZjZjKYKYKYKYKYHLKYKYKYKYKYZjZj
-ZjZjKYKYKYKYKYHLKYKYKYKYKYZjZj
-ZjZjHLHLHLHLHLHLHLHLHLHLHLZjZj
-ZjZjKYKYKYKYKYHLKYKYKYKYKYZjZj
-ZjZjKYKYKYKYKYHLKYKYKYKYKYZjZj
-ZjZjHLHLHLHLHLHLHLHLHLHLHLZjZj
-ZjZjKYKYKYKYKYHLKYKYKYKYKYZjZj
-ZjZjZjZjZjZjZjbsetZjZjZjZjZjZj
-WbWbWbWbWbZjEDfyEDZjZjZjZjZjZj
-WbxbxbxbWbZjEDgKEDZjbqZjZjZjZj
-WbxbOOxbWbWbEDndEDWboxWbZjZjZj
-WbxbxbxbhwhSrerowlBDcgWbWbZjZj
-WbWbDExbEIFjFjKnFjjiNdvZWbZjZj
-ZjWbxbOBONPyKnKnKnQBIwRDWbZjZj
-EDEDEDRLRSKnUlUvULKnYBZpEDEDED
-fwKekvbGvdvdInHlyGvdvdUwfwKekv
-EDEDEDGOHpKngpeEgxKnKfyiEDEDED
-ZjZjWbkIFjJzKnKnKnZGFjilWbZjZj
-ZjZjWbxbccFjFjKnFjFjfPgXWbZjZj
-ZjZjWbWbxbLXFURulYpZxbWbWbZjZj
-ZjZjZjWbWbWbEDOhEDWbWbWbZjZjZj
-ZjZjZjZjZjZjEDKeEDZjZjZjZjZjZj
-ZjZjZjZjZjZjEDnuEDZjZjZjZjZjZj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Wb
+Wb
+Wb
+Wb
+Wb
+Zj
+ED
+fw
+ED
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+"}
+(2,1,1) = {"
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Wb
+xb
+xb
+xb
+Wb
+Wb
+ED
+Ke
+ED
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+"}
+(3,1,1) = {"
+KY
+HL
+KY
+KY
+HL
+KY
+KY
+HL
+KY
+Zj
+Wb
+xb
+OO
+xb
+DE
+xb
+ED
+kv
+ED
+Wb
+Wb
+Wb
+Zj
+Zj
+Zj
+"}
+(4,1,1) = {"
+KY
+HL
+KY
+KY
+HL
+KY
+KY
+HL
+KY
+Zj
+Wb
+xb
+xb
+xb
+xb
+OB
+RL
+bG
+GO
+kI
+xb
+Wb
+Wb
+Zj
+Zj
+"}
+(5,1,1) = {"
+KY
+HL
+KY
+KY
+HL
+KY
+KY
+HL
+KY
+Zj
+Wb
+Wb
+Wb
+hw
+EI
+ON
+RS
+vd
+Hp
+Fj
+cc
+xb
+Wb
+Zj
+Zj
+"}
+(6,1,1) = {"
+KY
+HL
+KY
+KY
+HL
+KY
+KY
+HL
+KY
+Zj
+Zj
+Zj
+Wb
+hS
+Fj
+Py
+Kn
+vd
+Kn
+Jz
+Fj
+LX
+Wb
+Zj
+Zj
+"}
+(7,1,1) = {"
+KY
+HL
+KY
+KY
+HL
+KY
+KY
+HL
+KY
+Zj
+ED
+ED
+ED
+re
+Fj
+Kn
+Ul
+In
+gp
+Kn
+Fj
+FU
+ED
+ED
+ED
+"}
+(8,1,1) = {"
+ah
+HL
+HL
+HL
+HL
+HL
+HL
+HL
+HL
+bs
+fy
+gK
+nd
+ro
+Kn
+Kn
+Uv
+Hl
+eE
+Kn
+Kn
+Ru
+Oh
+Ke
+nu
+"}
+(9,1,1) = {"
+KY
+HL
+KY
+KY
+HL
+KY
+KY
+HL
+KY
+et
+ED
+ED
+ED
+wl
+Fj
+Kn
+UL
+yG
+gx
+Kn
+Fj
+lY
+ED
+ED
+ED
+"}
+(10,1,1) = {"
+KY
+HL
+KY
+KY
+HL
+KY
+KY
+HL
+KY
+Zj
+Zj
+Zj
+Wb
+BD
+ji
+QB
+Kn
+vd
+Kn
+ZG
+Fj
+pZ
+Wb
+Zj
+Zj
+"}
+(11,1,1) = {"
+KY
+HL
+KY
+KY
+HL
+KY
+KY
+HL
+KY
+Zj
+Zj
+bq
+ox
+cg
+Nd
+Iw
+YB
+vd
+Kf
+Fj
+fP
+xb
+Wb
+Zj
+Zj
+"}
+(12,1,1) = {"
+KY
+HL
+KY
+KY
+HL
+KY
+KY
+HL
+KY
+Zj
+Zj
+Zj
+Wb
+Wb
+vZ
+RD
+Zp
+Uw
+yi
+il
+gX
+Wb
+Wb
+Zj
+Zj
+"}
+(13,1,1) = {"
+KY
+HL
+KY
+KY
+HL
+KY
+KY
+HL
+KY
+Zj
+Zj
+Zj
+Zj
+Wb
+Wb
+Wb
+ED
+fw
+ED
+Wb
+Wb
+Wb
+Zj
+Zj
+Zj
+"}
+(14,1,1) = {"
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+ED
+Ke
+ED
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+"}
+(15,1,1) = {"
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
+ED
+kv
+ED
+Zj
+Zj
+Zj
+Zj
+Zj
+Zj
 "}

--- a/_maps/RandomRuins/SpaceRuins/jolly_nerva.dmm
+++ b/_maps/RandomRuins/SpaceRuins/jolly_nerva.dmm
@@ -1,0 +1,100 @@
+"ah" = (/obj/machinery/power/tracker,/obj/structure/cable,/turf/open/floor/iron/solarpanel/airless,/area/solars/nerva)
+"bq" = (/obj/structure/lattice/catwalk,/obj/machinery/atmospherics/components/unary/outlet_injector/layer2,/turf/template_noop,/area/ruin/space/has_grav/nerva)
+"bs" = (/obj/structure/lattice/catwalk,/obj/item/stack/cable_coil/cut,/turf/template_noop,/area/solars/nerva)
+"bG" = (/obj/effect/turf_decal/stripes/line{dir = 8},/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
+"cc" = (/turf/open/floor/iron/dark/corner{dir = 8},/area/ruin/space/has_grav/nerva)
+"cg" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
+"et" = (/obj/item/food/deadmouse{desc = "Poor fella."; name = "\proper Tom the Space Mouse"},/turf/template_noop,/area/template_noop)
+"eE" = (/obj/effect/turf_decal/tile/purple{dir = 1},/obj/effect/turf_decal/tile/purple{dir = 4},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"fw" = (/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 4},/obj/machinery/door/airlock/external/glass,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
+"fy" = (/obj/structure/cable,/obj/machinery/door/airlock/external/glass,/obj/effect/mapping_helpers/airlock/cyclelink_helper,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
+"fP" = (/turf/open/floor/iron/dark/corner,/area/ruin/space/has_grav/nerva)
+"gp" = (/obj/effect/turf_decal/tile/purple{dir = 4},/turf/open/floor/iron/corner{dir = 4},/area/ruin/space/has_grav/nerva)
+"gx" = (/obj/effect/turf_decal/tile/purple{dir = 1},/turf/open/floor/iron/corner{dir = 1},/area/ruin/space/has_grav/nerva)
+"gK" = (/obj/structure/cable,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
+"gX" = (/obj/item/gps/spaceruin,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
+"hw" = (/obj/machinery/atmospherics/components/unary/tank/air,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
+"hS" = (/obj/structure/cable,/obj/machinery/power/solar_control,/obj/machinery/light/directional{dir = 1},/turf/open/floor/iron/dark/side{dir = 9},/area/ruin/space/has_grav/nerva)
+"il" = (/obj/machinery/light/directional{dir = 4},/turf/open/floor/iron/dark/side{dir = 6},/area/ruin/space/has_grav/nerva)
+"ji" = (/obj/structure/cable,/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"kv" = (/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 8},/obj/machinery/door/airlock/external/glass,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
+"kI" = (/obj/machinery/light/directional{dir = 8},/turf/open/floor/iron/dark/side{dir = 10},/area/ruin/space/has_grav/nerva)
+"lY" = (/obj/effect/turf_decal/stripes/corner{dir = 8},/turf/open/floor/iron/dark/corner,/area/ruin/space/has_grav/nerva)
+"nd" = (/obj/structure/cable,/obj/machinery/door/airlock/external/glass,/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 1},/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
+"nu" = (/obj/effect/mapping_helpers/airlock/cyclelink_helper{dir = 1},/obj/machinery/door/airlock/external/glass,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
+"ox" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
+"pZ" = (/obj/machinery/light/directional,/turf/open/floor/iron/dark/side{dir = 6},/area/ruin/space/has_grav/nerva)
+"re" = (/obj/structure/cable,/obj/effect/turf_decal/stripes/corner{dir = 4},/turf/open/floor/iron/dark/corner{dir = 1},/area/ruin/space/has_grav/nerva)
+"ro" = (/obj/structure/cable,/obj/machinery/power/terminal{dir = 4},/obj/effect/turf_decal/stripes/line{dir = 1},/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
+"vd" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
+"vZ" = (/obj/machinery/airalarm/directional/east,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
+"wl" = (/obj/structure/cable,/obj/machinery/power/smes/engineering{charge = 0},/obj/effect/turf_decal/stripes/corner{dir = 1},/turf/open/floor/iron/dark/corner{dir = 4},/area/ruin/space/has_grav/nerva)
+"xb" = (/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
+"yi" = (/obj/effect/turf_decal/stripes/corner{dir = 4},/turf/open/floor/iron/dark/corner,/area/ruin/space/has_grav/nerva)
+"yG" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/obj/effect/turf_decal/tile/purple{dir = 1},/obj/effect/turf_decal/tile/purple{dir = 8},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"BD" = (/obj/structure/cable,/obj/machinery/power/apc/auto_name/north,/turf/open/floor/iron/dark/side{dir = 5},/area/ruin/space/has_grav/nerva)
+"DE" = (/obj/machinery/light/directional{dir = 8},/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
+"ED" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
+"EI" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron/dark/corner{dir = 1},/area/ruin/space/has_grav/nerva)
+"Fj" = (/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"FU" = (/obj/effect/turf_decal/stripes/corner,/turf/open/floor/iron/dark/corner{dir = 8},/area/ruin/space/has_grav/nerva)
+"GO" = (/obj/effect/turf_decal/stripes/corner{dir = 1},/turf/open/floor/iron/dark/corner{dir = 8},/area/ruin/space/has_grav/nerva)
+"Hl" = (/obj/machinery/spaceship_navigation_beacon,/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/turf/open/floor/iron/smooth_large,/area/ruin/space/has_grav/nerva)
+"Hp" = (/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{dir = 1},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"HL" = (/obj/structure/lattice/catwalk,/obj/structure/cable,/turf/template_noop,/area/solars/nerva)
+"In" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/obj/effect/turf_decal/tile/purple,/obj/effect/turf_decal/tile/purple{dir = 4},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"Iw" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"Jz" = (/turf/open/floor/iron/corner{dir = 8},/area/ruin/space/has_grav/nerva)
+"Ke" = (/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
+"Kf" = (/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{dir = 1},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"Kn" = (/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
+"KY" = (/obj/machinery/power/solar,/obj/structure/cable,/turf/open/floor/iron/solarpanel/airless,/area/solars/nerva)
+"LX" = (/obj/machinery/light/directional,/turf/open/floor/iron/dark/side{dir = 10},/area/ruin/space/has_grav/nerva)
+"Nd" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/turf/open/floor/iron/dark/corner{dir = 4},/area/ruin/space/has_grav/nerva)
+"Oh" = (/obj/effect/mapping_helpers/airlock/cyclelink_helper,/obj/machinery/door/airlock/external/glass,/turf/open/floor/plating,/area/ruin/space/has_grav/nerva)
+"OB" = (/turf/open/floor/iron/dark/side{dir = 9},/area/ruin/space/has_grav/nerva)
+"ON" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"OO" = (/obj/machinery/gravity_generator/main/station,/turf/open/floor/iron/dark,/area/ruin/space/has_grav/nerva)
+"Py" = (/turf/open/floor/iron/corner{dir = 1},/area/ruin/space/has_grav/nerva)
+"QB" = (/turf/open/floor/iron/corner{dir = 4},/area/ruin/space/has_grav/nerva)
+"Ru" = (/obj/effect/turf_decal/stripes/line,/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
+"RD" = (/obj/machinery/light/directional{dir = 4},/turf/open/floor/iron/dark/side{dir = 5},/area/ruin/space/has_grav/nerva)
+"RL" = (/obj/effect/turf_decal/stripes/corner{dir = 8},/turf/open/floor/iron/dark/corner{dir = 1},/area/ruin/space/has_grav/nerva)
+"RS" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"Ul" = (/obj/effect/turf_decal/tile/purple,/obj/effect/turf_decal/tile/purple,/turf/open/floor/iron/corner,/area/ruin/space/has_grav/nerva)
+"Uv" = (/obj/effect/turf_decal/tile/purple,/obj/effect/turf_decal/tile/purple{dir = 8},/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"Uw" = (/obj/effect/turf_decal/stripes/line{dir = 4},/turf/open/floor/iron/large,/area/ruin/space/has_grav/nerva)
+"UL" = (/obj/effect/turf_decal/tile/purple{dir = 8},/turf/open/floor/iron/corner{dir = 8},/area/ruin/space/has_grav/nerva)
+"Wb" = (/turf/closed/wall/r_wall,/area/ruin/space/has_grav/nerva)
+"YB" = (/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{dir = 8},/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,/turf/open/floor/iron,/area/ruin/space/has_grav/nerva)
+"Zj" = (/turf/template_noop,/area/template_noop)
+"Zp" = (/obj/effect/turf_decal/stripes/corner,/turf/open/floor/iron/dark/corner{dir = 4},/area/ruin/space/has_grav/nerva)
+"ZG" = (/turf/open/floor/iron/corner,/area/ruin/space/has_grav/nerva)
+
+(1,1,1) = {"
+ZjZjKYKYKYKYKYahKYKYKYKYKYZjZj
+ZjZjHLHLHLHLHLHLHLHLHLHLHLZjZj
+ZjZjKYKYKYKYKYHLKYKYKYKYKYZjZj
+ZjZjKYKYKYKYKYHLKYKYKYKYKYZjZj
+ZjZjHLHLHLHLHLHLHLHLHLHLHLZjZj
+ZjZjKYKYKYKYKYHLKYKYKYKYKYZjZj
+ZjZjKYKYKYKYKYHLKYKYKYKYKYZjZj
+ZjZjHLHLHLHLHLHLHLHLHLHLHLZjZj
+ZjZjKYKYKYKYKYHLKYKYKYKYKYZjZj
+ZjZjZjZjZjZjZjbsetZjZjZjZjZjZj
+WbWbWbWbWbZjEDfyEDZjZjZjZjZjZj
+WbxbxbxbWbZjEDgKEDZjbqZjZjZjZj
+WbxbOOxbWbWbEDndEDWboxWbZjZjZj
+WbxbxbxbhwhSrerowlBDcgWbWbZjZj
+WbWbDExbEIFjFjKnFjjiNdvZWbZjZj
+ZjWbxbOBONPyKnKnKnQBIwRDWbZjZj
+EDEDEDRLRSKnUlUvULKnYBZpEDEDED
+fwKekvbGvdvdInHlyGvdvdUwfwKekv
+EDEDEDGOHpKngpeEgxKnKfyiEDEDED
+ZjZjWbkIFjJzKnKnKnZGFjilWbZjZj
+ZjZjWbxbccFjFjKnFjFjfPgXWbZjZj
+ZjZjWbWbxbLXFURulYpZxbWbWbZjZj
+ZjZjZjWbWbWbEDOhEDWbWbWbZjZjZj
+ZjZjZjZjZjZjEDKeEDZjZjZjZjZjZj
+ZjZjZjZjZjZjEDnuEDZjZjZjZjZjZj
+"}

--- a/config/spaceruinblacklist.txt
+++ b/config/spaceruinblacklist.txt
@@ -48,4 +48,5 @@ _maps/RandomRuins/SpaceRuins/thederelict.dmm
 #_maps/RandomRuins/SpaceRuins/whiteshipdock.dmm
 #_maps/RandomRuins/SpaceRuins/whiteshipruin_box.dmm
 _maps/RandomRuins/SpaceRuins/forgottenship.dmm
-
+#_maps/RandomRuins/SpaceRuins/jolly_berry.dmm
+#_maps/RandomRuins/SpaceRuins/jolly_nerva.dmm

--- a/jollystation.dme
+++ b/jollystation.dme
@@ -3618,6 +3618,7 @@
 #include "jollystation_modules\code\datums\quirks\good.dm"
 #include "jollystation_modules\code\datums\quirks\negative.dm"
 #include "jollystation_modules\code\datums\quirks\neutral.dm"
+#include "jollystation_modules\code\datums\ruins\space.dm"
 #include "jollystation_modules\code\game\area\space_station_13_areas.dm"
 #include "jollystation_modules\code\game\objects\unique_examine_items.dm"
 #include "jollystation_modules\code\game\objects\effects\landmarks.dm"

--- a/jollystation_modules/code/datums/ruins/space.dm
+++ b/jollystation_modules/code/datums/ruins/space.dm
@@ -1,0 +1,13 @@
+// Hey! Listen! Update \config\spaceruinblacklist.txt with your new ruins!
+
+/datum/map_template/ruin/space/jolly_berry
+	id = "jolly_berry"
+	suffix = "jolly_berry.dmm"
+	name = "Berry Physics"
+	description = "Proof that the real binding element of the universe, the base of it all... Is just berries."
+
+/datum/map_template/ruin/space/jolly_nerva
+	id = "jolly_nerva"
+	suffix = "jolly_nerva.dmm"
+	name = "NERVA Beacon"
+	description = "An old, deserted beacon for spacefarers. Could probably be used for space construction projects."

--- a/jollystation_modules/code/game/area/space_station_13_areas.dm
+++ b/jollystation_modules/code/game/area/space_station_13_areas.dm
@@ -9,3 +9,17 @@
 	name = "Bridge Officer's Office"
 	icon = 'jollystation_modules/icons/turf/areas.dmi'
 	icon_state = "bo_office"
+
+//Berry Physics Space Ruin
+/area/ruin/space/has_grav/powered/berry_physics
+	name = "Berry Physics"
+	icon_state = "red"
+
+//NERVA Station
+/area/ruin/space/has_grav/nerva
+	name = "NERVA Beacon"
+	icon_state = "green"
+
+/area/solars/nerva
+	name = "NERVA Beacon Solar Array"
+	icon_state = "panelsP"


### PR DESCRIPTION
## About The Pull Request

Adds in two new space ruins, as shown here.

![https://i.imgur.com/fxJcjyT.png](https://i.imgur.com/fxJcjyT.png)
_My god. It's been true all along... Also, there is an omnilathe board. One of a kind._

![https://i.imgur.com/reS02RR.png](https://i.imgur.com/reS02RR.png)
_An abandoned space outpost. With an atmospherics system, gravity generator, gigabeacon and solar array, it is the perfect location to construct any makeshift space station._

## Why It's Good For The Game

New interesting ruins designed to promote base construction and as a result, player creativity.

## Changelog
:cl:
add: Two new space ruins have drifted into the sector around Indecipheres. Information about them is unknown.
/:cl: