### PR TITLE
Adds back in the ORM part upgrades.

### DIFF
--- a/jollystation.dme
+++ b/jollystation.dme
@@ -3670,6 +3670,7 @@
 #include "jollystation_modules\code\modules\jobs\job_types\xenobiologist.dm"
 #include "jollystation_modules\code\modules\language\highdraconic.dm"
 #include "jollystation_modules\code\modules\language\skrellian.dm"
+#include "jollystation_modules\code\modules\mining\mining_redemption.dm"
 #include "jollystation_modules\code\modules\mob\logout.dm"
 #include "jollystation_modules\code\modules\mob\mob.dm"
 #include "jollystation_modules\code\modules\mob\mob_defines.dm"

--- a/jollystation_modules/code/modules/mining/mining_redemption.dm
+++ b/jollystation_modules/code/modules/mining/mining_redemption.dm
@@ -1,0 +1,10 @@
+///Adds back in upgrades to the Ore Redemption Machine.
+/obj/machinery/mineral/ore_redemption/RefreshParts()
+	var/point_upgrade_temp = 1
+	var/ore_multiplier_temp = 1
+	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
+		ore_multiplier_temp = 0.65 + (0.35 * B.rating)
+	for(var/obj/item/stock_parts/micro_laser/L in component_parts)
+		point_upgrade_temp = 0.65 + (0.35 * L.rating)
+	point_upgrade = point_upgrade_temp
+	ore_multiplier = round(ore_multiplier_temp, 0.01)


### PR DESCRIPTION
## About The Pull Request

This PR adds back in, modularily, the ORM's part upgrades causing it to get 2x ore and 2x points at the highest part levels.
![https://i.imgur.com/EbOgtM8.png](https://i.imgur.com/EbOgtM8.png)

## Why It's Good For The Game

We're a lowpop server low on miners, and it gives more of an incentive for science to research tier 4 parts i guess.

## Changelog
:cl:
add: The Ore Redemption Machine is now upgradeable again, in order to make it give out double ore and double points.
/:cl: