### PR TITLE
Merge Driver Update

### DIFF
--- a/_merge_driver.bash
+++ b/_merge_driver.bash
@@ -2,7 +2,7 @@
 
 find_all_in_dir (){
 
-	if [ ! -f $1 ]; then
+	if [ ! -d $1 ]; then
 		echo "!! find_all_in_dir error: $1 directory not found."
 		return 1
 	fi
@@ -18,7 +18,7 @@ find_all_in_dir (){
 			continue
 		fi
 
-		if grep -q "// NON-MODULE" "$file"; then
+		if grep -q -i -E "\/{2,}\s*non(\s|-)*module" "$file"; then
 			echo "NOTICE: $file contains modular changes, and must be done manually."
 			continue
 		fi

--- a/_merge_driver.bash
+++ b/_merge_driver.bash
@@ -66,8 +66,8 @@ update_build (){
 }
 
 echo "Running merge driver. . ."
-#find_all_in_dir "code"
-#find_all_in_dir "tgui"
+find_all_in_dir "code"
+find_all_in_dir "tgui"
 echo "Conflict checking done. Updating DME."
 update_dme tgstation.dme jollystation.dme
 echo "DME update down. Updating build.js"

--- a/_merge_driver.bash
+++ b/_merge_driver.bash
@@ -44,6 +44,12 @@ update_dme (){
 		return 1
 	fi
 
+	if grep -q "<<<<<<<" $1; then
+		sed -i '/<<<<<<</,/=======/d' $1
+		sed -i '/>>>>>>>/d' $1
+		echo "$1 merge conflicts resolved before updating modular DME.."
+	fi
+
 	tempfile=temp_"$1"
 	sed '$d' $1 >> $tempfile
 	grep '#include "jollystation_modules' $2 >> $tempfile
@@ -60,8 +66,8 @@ update_build (){
 }
 
 echo "Running merge driver. . ."
-find_all_in_dir "code"
-find_all_in_dir "tgui"
+#find_all_in_dir "code"
+#find_all_in_dir "tgui"
 echo "Conflict checking done. Updating DME."
 update_dme tgstation.dme jollystation.dme
 echo "DME update down. Updating build.js"


### PR DESCRIPTION
- Fixed an issue in which it wanted the provided directories to be files
- comment checking grep now uses extended regular expression instead of hardcoded string
- dme updater now resolve merge conflicts before combining dmes