### PR TITLE
Updates everything to be correctly +15 years from /tg/ time.

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -490,7 +490,7 @@
 				var/counter = 1
 				while(active2.fields[text("com_[]", counter)])
 					counter++
-				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [] [], []<BR>[]", authenticated, rank, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+540, t1)
+				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [] [], []<BR>[]", authenticated, rank, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+555, t1) // NON-MODULE CHANGE; Default year increment is 540, Jollystation is +15 years from that.
 
 			else if(href_list["del_c"])
 				if((istype(active2, /datum/data/record) && active2.fields[text("com_[]", href_list["del_c"])]))

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -674,7 +674,7 @@ What a mess.*/
 				var/counter = 1
 				while(active2.fields[text("com_[]", counter)])
 					counter++
-				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [] [], []<BR>[]", src.authenticated, src.rank, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+540, t1)
+				active2.fields[text("com_[]", counter)] = text("Made by [] ([]) on [] [], []<BR>[]", src.authenticated, src.rank, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+555, t1) // NON-MODULE CHANGE; Default year increment is 540, Jollystation is +15 years from that.
 
 			if("Delete Record (ALL)")
 				if(active1)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -259,7 +259,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 				dat += text("<br><a href='?src=[REF(src)];choice=UpdateInfo'>[id ? "Update PDA Info" : ""]</A><br><br>")
 
 				dat += "[station_time_timestamp()]<br>" //:[world.time / 100 % 6][world.time / 100 % 10]"
-				dat += "[time2text(world.realtime, "MMM DD")] [GLOB.year_integer+540]"
+				dat += "[time2text(world.realtime, "MMM DD")] [GLOB.year_integer+555]" // NON-MODULE CHANGE; Default year increment is 540, Jollystation is +15 years from that.
 
 				dat += "<br><br>"
 

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -269,14 +269,14 @@
 		LAZYSET(W.data,"vintage",wine_info)
 
 /obj/item/reagent_containers/food/drinks/bottle/wine/proc/generate_vintage()
-	return "[GLOB.year_integer + 540] Nanotrasen Light Red"
+	return "[GLOB.year_integer + 555] Nanotrasen Light Red" // NON-MODULE CHANGE; Default year increment is 540, Jollystation is +15 years from that.
 
 /obj/item/reagent_containers/food/drinks/bottle/wine/unlabeled
 	name = "unlabeled wine bottle"
 	desc = "There's no label on this wine bottle."
 
 /obj/item/reagent_containers/food/drinks/bottle/wine/unlabeled/generate_vintage()
-	var/current_year = GLOB.year_integer + 540
+	var/current_year = GLOB.year_integer + 555 // NON-MODULE CHANGE; Default year increment is 540, Jollystation is +15 years from that.
 	var/year = rand(current_year-50,current_year)
 	var/type = pick("Sparkling","Dry White","Sweet White","Rich White","Rose","Light Red","Medium Red","Bold Red","Dessert")
 	var/origin = pick("Nanotrasen","Syndicate","Local")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -352,7 +352,7 @@
 				var/counter = 1
 				while(R.fields[text("com_[]", counter)])
 					counter++
-				R.fields[text("com_[]", counter)] = text("Made by [] on [] [], []<BR>[]", allowed_access, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+540, t1)
+				R.fields[text("com_[]", counter)] = text("Made by [] on [] [], []<BR>[]", allowed_access, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+555, t1) // NON-MODULE CHANGE; Default year increment is 540, Jollystation is +15 years from that.
 				to_chat(usr, span_notice("Successfully added comment."))
 				return
 

--- a/jollystation_modules/README.md
+++ b/jollystation_modules/README.md
@@ -107,6 +107,7 @@ To prevent me from accidentally accept incoming on files with module changes, I'
 - code\game\machinery\computer\crew.dm
 - code\game\machinery\computer\medical.dm
 - code\game\machinery\computer\security.dm
+- code\game\objects\items\devices\PDA\PDA.dm
 - code\game\objects\items\implants\implantuplink.dm
 - code\game\objects\items\plushes.dm
 - code\game\objects\items\scanners.dm
@@ -116,6 +117,7 @@ To prevent me from accidentally accept incoming on files with module changes, I'
 - code\modules\client\client_procs.dm
 - code\modules\client\preferences_savefile.dm
 - code\modules\client\preferences.dm
+- code\modules\food_and_drinks\drinks\drinks\bottle.dm
 - code\modules\jobs\jobs.dm
 - code\modules\jobs\job_types\_job.dm
 - code\modules\jobs\job_types\cargo_technician.dm
@@ -125,6 +127,7 @@ To prevent me from accidentally accept incoming on files with module changes, I'
 - code\modules\jobs\job_types\scientist.dm
 - code\modules\jobs\job_types\shaft_miner.dm
 - code\modules\language\language_holder.dm
+- code\modules\mob\living\carbon\human\human.dm
 - code\modules\mob\living\carbon\human\species.dm
 - code\modules\modular_computers\file_system\programs\jobmanagement.dm
 - code\modules\surgery\bodyparts\dismemberment.dm

--- a/jollystation_modules/code/game/objects/unique_examine_items.dm
+++ b/jollystation_modules/code/game/objects/unique_examine_items.dm
@@ -86,7 +86,7 @@
 
 /obj/item/reagent_containers/food/drinks/bottle/lizardwine/Initialize()
 	. = ..()
-	var/vintage = rand(GLOB.year_integer + 450, GLOB.year_integer + 540) // Wine has an actual vintage var but lizardwine is special
+	var/vintage = rand(GLOB.year_integer + 450, GLOB.year_integer + 555) // Wine has an actual vintage var but lizardwine is special // NON-MODULE CHANGE; Default year increment is 540, Jollystation is +15 years from that. And yes, this does make these wines able to be older.
 	AddElement(/datum/element/unique_examine, "A bottle of ethically questionable lizard wine. Rare now-a-days following the harsh regulations placed on the great wine industry. You'd place the vintage at... [(vintage >= 3000) ? "[vintage] Nanotrasen White-Green. Not my personal preference..." : "a respectable [vintage] Nanotrasen White-Green. Wonderful."]", EXAMINE_CHECK_SKILLCHIP, list(/obj/item/skillchip/wine_taster), hint = FALSE)
 	AddElement(/datum/element/unique_examine, "A lizardperson's tail is important in keeping balance and warding off enemies in combat situations. You can't help but feel disappointed and saddened looking at this, knowing a fellow kin was robbed of such a thing.", EXAMINE_CHECK_SPECIES, LIZARD_LIST)
 

--- a/jollystation_modules/code/game/objects/unique_examine_items.dm
+++ b/jollystation_modules/code/game/objects/unique_examine_items.dm
@@ -86,7 +86,7 @@
 
 /obj/item/reagent_containers/food/drinks/bottle/lizardwine/Initialize()
 	. = ..()
-	var/vintage = rand(GLOB.year_integer + 450, GLOB.year_integer + 555) // Wine has an actual vintage var but lizardwine is special // NON-MODULE CHANGE; Default year increment is 540, Jollystation is +15 years from that. And yes, this does make these wines able to be older.
+	var/vintage = rand(GLOB.year_integer + 450, GLOB.year_integer + 555) // Wine has an actual vintage var but lizardwine is special
 	AddElement(/datum/element/unique_examine, "A bottle of ethically questionable lizard wine. Rare now-a-days following the harsh regulations placed on the great wine industry. You'd place the vintage at... [(vintage >= 3000) ? "[vintage] Nanotrasen White-Green. Not my personal preference..." : "a respectable [vintage] Nanotrasen White-Green. Wonderful."]", EXAMINE_CHECK_SKILLCHIP, list(/obj/item/skillchip/wine_taster), hint = FALSE)
 	AddElement(/datum/element/unique_examine, "A lizardperson's tail is important in keeping balance and warding off enemies in combat situations. You can't help but feel disappointed and saddened looking at this, knowing a fellow kin was robbed of such a thing.", EXAMINE_CHECK_SPECIES, LIZARD_LIST)
 


### PR DESCRIPTION
## About The Pull Request

Every instance of the +540 year increment is updated to the +555 increment now, with a note on it being a non-module change.

## Why It's Good For The Game

The time is now accurate, and we can tell what time we actually are now.

Also the better solution to this would be to change the time increment to a config option, but that's a refactor for /tg/ to do.