### PR TITLE
Somewhat effectively disbles random hardcore

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2081,7 +2081,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		var/datum/antagonist/antag
 		if(antag.get_team()) //No team antags
 			return FALSE
-	return TRUE
+	return FALSE // NON-MODULE CHANGE: Disable random hardcore
 
 /datum/preferences/proc/get_default_name(name_id)
 	switch(name_id)


### PR DESCRIPTION
No one's ever gonna use it, but if someone does use it, it will likely break things. Might as well prevent random hardcore characters from generating in that event.