### PR TITLE
Fixes(sort of) a null client runtime with flavor text

### DIFF
--- a/jollystation_modules/code/modules/mob/living/carbon/human/flavor_text.dm
+++ b/jollystation_modules/code/modules/mob/living/carbon/human/flavor_text.dm
@@ -14,6 +14,8 @@ GLOBAL_LIST_EMPTY(flavor_texts)
  * Create a flavor text datum for [added_client].
  */
 /proc/add_client_flavor_text(client/added_client)
+	if(!added_client)
+		return FALSE
 	if(!added_client.prefs)
 		return FALSE
 	if(!added_client.prefs.flavor_text && !added_client.prefs.general_records && !added_client.prefs.medical_records && !added_client.prefs.security_records)


### PR DESCRIPTION
Clients are wild unpredictable creatures. This is more of a bandaid than a fix but whatever.