### PR TITLE
Painkillers: Miner pen buff, emergency kit pen perf

### DIFF
--- a/jollystation_modules/code/modules/mob/living/carbon/pain_implements.dm
+++ b/jollystation_modules/code/modules/mob/living/carbon/pain_implements.dm
@@ -178,27 +178,27 @@
 	for(var/i in 1 to 2)
 		new /obj/item/reagent_containers/pill/oxycodone(src)
 
-/// Miner pen.
+/// Miner pen. Heals about 30 pain to all limbs, causes ~150 addiction
 /obj/item/reagent_containers/hypospray/medipen/survival/painkiller
 	name = "survival painkiller medipen"
-	desc = "A medipen that contains a dosage of heavy duty painkillers. WARNING: Side effects or addiction may occur with rapid consecutive usage. Do not use in combination with alcohol."
+	desc = "A medipen that contains a dosage of painkilling chemicals. WARNING: Do not use in combination with alcohol. Can cause drowsiness."
 	icon = 'jollystation_modules/icons/obj/syringe.dmi'
 	icon_state = "painkiller_stimpen"
 	base_icon_state = "painkiller_stimpen"
-	volume = 15
-	amount_per_transfer_from_this = 15
-	list_reagents = list(/datum/reagent/medicine/oxycodone = 7.5, /datum/reagent/medicine/morphine = 5, /datum/reagent/medicine/modafinil = 2.5)
+	volume = 20
+	amount_per_transfer_from_this = 20
+	list_reagents = list(/datum/reagent/medicine/painkiller/paracetamol = 7.5, /datum/reagent/medicine/painkiller/aspirin_para_coffee = 5, /datum/reagent/medicine/morphine = 5, /datum/reagent/medicine/modafinil = 2.5)
 
-/// Medkit pen.
+/// Medkit pen. Heals about 35 pain to all limbs, causes ~450 addiction
 /obj/item/reagent_containers/hypospray/medipen/painkiller
 	name = "emergency painkiller medipen"
-	desc = "A medipen that contains a dosages of moderate painkilling chemicals. Can cause drowsiness. WARNING: Do not use in combination with alcohol."
+	desc = "A medipen that contains a dosage of heavy painkilling chemicals. WARNING: Do not use in combination with alcohol. Can cause drowsiness and addiction."
 	icon = 'jollystation_modules/icons/obj/syringe.dmi'
 	icon_state = "painkiller"
 	base_icon_state = "painkiller"
 	volume = 15
 	amount_per_transfer_from_this = 15
-	list_reagents = list(/datum/reagent/medicine/painkiller/paracetamol = 7.5, /datum/reagent/medicine/painkiller/aspirin_para_coffee = 5, /datum/reagent/medicine/morphine = 2.5)
+	list_reagents = list(/datum/reagent/medicine/oxycodone = 7.5, /datum/reagent/medicine/morphine = 5, /datum/reagent/medicine/modafinil = 2.5)
 
 /*
  * Shock blanket item. Hit someone to cover them with the blanket.

--- a/jollystation_modules/code/modules/mob/living/carbon/pain_reagents.dm
+++ b/jollystation_modules/code/modules/mob/living/carbon/pain_reagents.dm
@@ -305,6 +305,7 @@
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
 	color = "#e695ff"
 	metabolization_rate = REAGENTS_METABOLISM
+	pain_modifier = 0.6
 
 /datum/reagent/medicine/painkiller/aspirin_para_coffee/on_mob_life(mob/living/carbon/M, delta_time, times_fired)
 	. = ..()


### PR DESCRIPTION
- The painkiller survival pen now heals slightly less pain than it did before, but addicts you 3x slower, which means you can take 4-5 pens before getting addicted now.
- The emergency painkiller pen now heals slightly more pain but addicts you 3x faster. Using 2 emergency painkiller pens will addict you now, as they're intended... for emergencies.
- aspirin / paracetamol / caffeine now has a pain modifier like the other painkillers.