### PR TITLE
Optimizes loadout icon generation (for less lag)

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -542,8 +542,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	general_records = strip_html_simple(sanitize_text(general_records), MAX_FLAVOR_LEN)
 	exploitable_info = strip_html_simple(sanitize_text(exploitable_info), MAX_FLAVOR_LEN)
 
-	sanitize_loadout_list(loadout_list)
-	sanitize_greyscale_list(greyscale_loadout_list)
+	loadout_list = sanitize_loadout_list(loadout_list)
+	greyscale_loadout_list = sanitize_greyscale_list(greyscale_loadout_list)
 	// NON-MODULE CHANGE END
 
 	persistent_scars = sanitize_integer(persistent_scars)

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -19,7 +19,7 @@
 	set name = "Game Preferences"
 	set category = "Preferences"
 	set desc = "Open Game Preferences Window"
-	usr.client.prefs.current_tab = 1
+	usr.client.prefs.current_tab = 2 // NON-MODULE CHANGE
 	usr.client.prefs.ShowChoices(usr)
 
 /datum/verbs/menu/settings/ghost

--- a/jollystation_modules/README.md
+++ b/jollystation_modules/README.md
@@ -123,6 +123,7 @@ To prevent me from accidentally accept incoming on files with module changes, I'
 - code\modules\antagonists\traitor\datum_traitor.dm
 - code\modules\client\client_procs.dm
 - code\modules\client\preferences_savefile.dm
+- code\modules\client\preferences_toggles.dm
 - code\modules\client\preferences.dm
 - code\modules\food_and_drinks\drinks\drinks\bottle.dm
 - code\modules\jobs\jobs.dm

--- a/jollystation_modules/code/modules/antagonists/_common/advanced_antag.dm
+++ b/jollystation_modules/code/modules/antagonists/_common/advanced_antag.dm
@@ -98,11 +98,10 @@
 /// This proc cleans up the open_panels list after a panel viewer closes the UI.
 /// viewer - the mob that just closed the panel.
 /datum/advanced_antag_datum/proc/cleanup_advanced_traitor_panel(mob/viewer)
-	open_panels[viewer] = null
 	open_panels -= viewer
 
 	if(!LAZYLEN(open_panels))
-		open_panels = null
+		LAZYNULL(open_panels)
 
 /// Modify the traitor's starting_points (TC, processing points, etc) based on their goals's intensity levels.
 /datum/advanced_antag_datum/proc/modify_antag_points()

--- a/jollystation_modules/code/modules/client/loadout_manager.dm
+++ b/jollystation_modules/code/modules/client/loadout_manager.dm
@@ -303,6 +303,7 @@
 
 	return data
 
+/// Generate a flat icon preview of our user, if we need to update it.
 /datum/loadout_manager/proc/generate_preview()
 	if(!dummy_key)
 		init_dummy()

--- a/jollystation_modules/code/modules/client/loadout_manager.dm
+++ b/jollystation_modules/code/modules/client/loadout_manager.dm
@@ -22,6 +22,10 @@
 	var/tutorial_status = FALSE
 	/// Our currently open greyscaling menu.
 	var/datum/greyscale_modify_menu/menu
+	/// Whether we need to update our dummy sprite next ui_data or not.
+	var/update_dummysprite = TRUE
+	/// Our preview sprite.
+	var/icon/dummysprite
 
 /datum/loadout_manager/New(user)
 	owner = CLIENT_FROM_VAR(user)
@@ -32,8 +36,8 @@
 	loadout_to_outfit()
 
 /datum/loadout_manager/ui_close(mob/user)
-	sanitize_loadout_list(owner.prefs.loadout_list)
-	sanitize_greyscale_list(owner.prefs.greyscale_loadout_list)
+	owner.prefs.loadout_list = sanitize_loadout_list(owner.prefs.loadout_list)
+	owner.prefs.greyscale_loadout_list = sanitize_greyscale_list(owner.prefs.greyscale_loadout_list)
 	if(menu)
 		SStgui.close_uis(menu)
 		menu = null
@@ -67,6 +71,7 @@
 		// Turns the tutorial on and off.
 		if("toggle_tutorial")
 			tutorial_status = !tutorial_status
+			return TRUE
 
 		// Either equips or de-equips the params["path"] item into params["category"]
 		if("select_item")
@@ -81,8 +86,7 @@
 		// Clears the loadout list entirely.
 		if("clear_all_items")
 			owner.prefs.loadout_list.Cut()
-			if(owner.prefs.greyscale_loadout_list)
-				owner.prefs.greyscale_loadout_list = null
+			LAZYNULL(owner.prefs.greyscale_loadout_list)
 
 		// Toggles between viewing favorite job clothes on the dummy.
 		if("toggle_job_clothes")
@@ -105,6 +109,7 @@
 
 	// Always update our loadout after we do something.
 	loadout_to_outfit()
+	update_dummysprite = TRUE
 	return TRUE
 
 /// Select [path] item to [category_slot] slot. If it's not a greyscale item, clear the corresponding greyscale slot too.
@@ -203,9 +208,9 @@
 
 	var/list/colors = open_menu.split_colors
 	if(colors)
-		if(!owner.prefs.greyscale_loadout_list)
-			owner.prefs.greyscale_loadout_list = list()
+		LAZYINITLIST(owner.prefs.greyscale_loadout_list)
 		owner.prefs.greyscale_loadout_list[category_slot] = colors.Join("")
+	update_dummysprite = TRUE
 
 /// Clears [category_slot]'s greyscale colors.
 /datum/loadout_manager/proc/clear_slot_greyscale(category_slot)
@@ -214,10 +219,9 @@
 	if(!owner.prefs.greyscale_loadout_list[category_slot])
 		return
 
-	owner.prefs.greyscale_loadout_list[category_slot] = null
 	owner.prefs.greyscale_loadout_list -= category_slot
 	if(!owner.prefs.greyscale_loadout_list.len)
-		owner.prefs.greyscale_loadout_list = null
+		LAZYNULL(owner.prefs.greyscale_loadout_list)
 
 /// Rotate the dummy [DIR] direction, or reset it to SOUTH dir if we're showing all dirs at once.
 /datum/loadout_manager/proc/rotate_model_dir(dir)
@@ -254,16 +258,8 @@
 
 /datum/loadout_manager/ui_data(mob/user)
 	var/list/data = list()
-	if(!dummy_key)
-		init_dummy()
 
-	var/icon/dummysprite = get_flat_human_icon(null,
-		dummy_key = dummy_key,
-		outfit_override = custom_loadout,
-		showDirs = dummy_dir,
-		prefs = owner.prefs,
-		)
-	data["icon64"] = icon2base64(dummysprite)
+	data["icon64"] = generate_preview()
 
 	var/list/all_selected_paths = list()
 	for(var/path_id in owner.prefs.loadout_list)
@@ -306,6 +302,22 @@
 	data["loadout_tabs"] = loadout_tabs
 
 	return data
+
+/datum/loadout_manager/proc/generate_preview()
+	if(!dummy_key)
+		init_dummy()
+
+	if(update_dummysprite)
+		dummysprite = get_flat_human_icon(
+			null,
+			dummy_key = dummy_key,
+			outfit_override = custom_loadout,
+			showDirs = dummy_dir,
+			prefs = owner.prefs,
+			)
+		update_dummysprite = FALSE
+
+	return icon2base64(dummysprite)
 
 /// Returns a formatted string for use in the UI.
 /datum/loadout_manager/proc/get_tutorial_text()

--- a/jollystation_modules/code/modules/client/loadout_outfit_helpers.dm
+++ b/jollystation_modules/code/modules/client/loadout_outfit_helpers.dm
@@ -165,44 +165,36 @@
  *
  * list_to_clean - the loadout list we're sanitizing.
  */
-/proc/sanitize_loadout_list(list/list_to_clean)
-	if(!istype(list_to_clean))
+/proc/sanitize_loadout_list(list/passed_list)
+	if(!istype(passed_list))
 		return
 
+	var/list/list_to_clean = passed_list.Copy()
 	for(var/slot in list_to_clean)
 		var/path = text2path(list_to_clean[slot])
-		if(isnull(path))
-			stack_trace("null value found in loadout list! Slot: [slot], Path: [path], Path Actual: [list_to_clean[slot]]")
+		if(!(slot in GLOB.loadout_slots))
+			stack_trace("invalid loadout slot found in loadout list! Slot: [slot], Path: [path]")
 			list_to_clean -= slot
 			continue
 
 		if(!ispath(path))
 			stack_trace("invalid path found in loadout list!  Slot: [slot], Path: [path], Path Actual: [list_to_clean[slot]]")
-			list_to_clean[slot] = null
-			list_to_clean -= slot
-			continue
-
-		if(!(slot in GLOB.loadout_slots))
-			stack_trace("invalid loadout slot found in loadout list! Slot: [slot], Path: [path]")
-			list_to_clean[slot] = null
 			list_to_clean -= slot
 
-	if(!list_to_clean.len)
-		list_to_clean = null
+	return list_to_clean.len ? list_to_clean : null
 
 /* Removes all bad slots from greyscale loadout lists.
  *
  * list_to_clean - the greyscale loadout list we're sanitizing.
  */
-/proc/sanitize_greyscale_list(list/list_to_clean)
-	if(!istype(list_to_clean))
+/proc/sanitize_greyscale_list(list/passed_list)
+	if(!istype(passed_list))
 		return
 
+	var/list/list_to_clean = passed_list.Copy()
 	for(var/slot in list_to_clean)
 		if(!(slot in GLOB.loadout_slots))
 			stack_trace("invalid loadout slot found in greyscale loadout list! Slot: [slot], Color: [list_to_clean[slot]]")
-			list_to_clean[slot] = null
 			list_to_clean -= slot
 
-	if(!list_to_clean.len)
-		list_to_clean = null
+	return list_to_clean.len ? list_to_clean : null


### PR DESCRIPTION
- Re-adjusts loadout list sanitization to be streamlined / work more efficiently
- Optimize loadout manager ui_data so getflaticon was not called 30 times per second - preview generation is now only done when the UI is updated or interacted with
- Adjusts some other lazylist manipulations

Loadout manager should run WAYYYY faster (like, 30% less time dilation when someone's using it, cause holy fuck)