### PR TITLE
Post Round Pubby Fixes

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2298,10 +2298,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
-"aia" = (
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "aid" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -4191,6 +4187,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"anv" = (
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "anw" = (
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/iron/dark,
@@ -11541,17 +11541,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"aMM" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "aMV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/artistic{
@@ -34447,16 +34436,6 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
-"ddi" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "dej" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -34582,16 +34561,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
-"dkA" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "dkU" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/landmark/start/prisoner,
@@ -35000,6 +34969,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/lounge)
+"dFV" = (
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "dGd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -35278,6 +35253,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/service/chapel/asteroid/monastery)
+"dUM" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "dUZ" = (
 /turf/closed/wall/r_wall,
 /area/cargo/storage)
@@ -35627,12 +35606,6 @@
 /obj/machinery/light/no_nightlight/directional/west,
 /turf/open/floor/iron/freezer,
 /area/security/prison/toilet)
-"epy" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "epJ" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -36089,6 +36062,12 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"eMy" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "eNo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -37351,21 +37330,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
-"fOa" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "fOq" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating/asteroid,
@@ -37659,16 +37623,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/medical/virology)
-"ghv" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ghx" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -37879,12 +37833,6 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"gqc" = (
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gqx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table,
@@ -38177,37 +38125,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/explab)
-"gDe" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gDq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
-"gDs" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "gDQ" = (
 /obj/machinery/door/poddoor/massdriver_trash,
 /obj/structure/fans/tiny,
@@ -38426,6 +38349,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"gKG" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gLd" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/green{
@@ -38694,6 +38628,18 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"hcI" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "HFR Room"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hdk" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -38946,11 +38892,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
-"htD" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "htK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -39251,6 +39192,21 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
+"hHP" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "hID" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -40048,6 +40004,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/engineering/gravity_generator)
+"iBo" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "iBp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -40099,13 +40060,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"iDb" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/engineering/atmos)
 "iDT" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -40799,13 +40753,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
-"jvD" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jwq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41129,12 +41076,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"jSY" = (
-/obj/effect/turf_decal/box/white{
-	color = "#EFB341"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "jTu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -41523,12 +41464,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/stairs/left,
 /area/service/abandoned_gambling_den)
-"kpB" = (
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "kqc" = (
 /obj/machinery/camera{
 	c_tag = "Incinerator";
@@ -41625,10 +41560,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
-"ksp" = (
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ksv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -41640,6 +41571,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/medical/virology)
+"ksU" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ktv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -41935,6 +41880,17 @@
 /obj/machinery/newscaster/security_unit/directional/south,
 /turf/open/floor/iron/dark,
 /area/security/interrogation)
+"kHv" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kHO" = (
 /obj/structure/bed/dogbed/renault,
 /mob/living/simple_animal/pet/fox/renault,
@@ -43347,6 +43303,14 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /turf/open/floor/iron,
 /area/medical/cryo)
+"mgY" = (
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/arrows/white{
+	color = "#0000FF";
+	pixel_y = 15
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mhL" = (
 /obj/structure/cable,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -44313,16 +44277,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
-"net" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/hfr_box/corner,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "nev" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -45819,10 +45773,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"oxd" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall,
-/area/service/chapel/main/monastery)
 "oxC" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -45901,6 +45851,13 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
+"oAH" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/engineering/atmos)
 "oAR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -47448,6 +47405,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/maintenance/department/engine)
+"pYS" = (
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "pZT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -48485,17 +48448,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/lobby)
-"qXX" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "qYn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -48894,6 +48846,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"rsR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "rsZ" = (
 /obj/machinery/camera/motion{
 	c_tag = "Telecomms External Access";
@@ -49788,6 +49746,13 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"sdb" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "sdk" = (
 /obj/structure/chair/wood{
 	dir = 1
@@ -50028,6 +49993,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
+"srz" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ssx" = (
 /obj/item/shard,
 /turf/open/floor/plating,
@@ -50731,6 +50706,10 @@
 	},
 /turf/open/floor/plating,
 /area/cargo/warehouse/upper)
+"sZt" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "sZu" = (
 /obj/item/storage/backpack/satchel/explorer,
 /turf/open/floor/plating,
@@ -51225,6 +51204,17 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"trA" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/rack,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "tta" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -51382,6 +51372,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
+"tyg" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "typ" = (
 /obj/structure/table/glass,
 /obj/item/hemostat,
@@ -52110,6 +52110,16 @@
 "ufo" = (
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"ugo" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ugv" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -53048,17 +53058,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"uTn" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/rack,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "uTt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -53071,24 +53070,6 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"uTz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
-"uTE" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "HFR Room"
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uTI" = (
@@ -53863,6 +53844,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/main)
+"vBG" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/service/chapel/main/monastery)
 "vBZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -54232,6 +54217,16 @@
 	},
 /turf/open/floor/iron,
 /area/maintenance/disposal)
+"vSL" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/hfr_box/corner,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vTg" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -54313,6 +54308,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/main)
+"vXu" = (
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "vXW" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -55489,14 +55490,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"wTA" = (
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/arrows/white{
-	color = "#0000FF";
-	pixel_y = 15
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wTD" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -55655,10 +55648,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
-"wYa" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wYi" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -55795,6 +55784,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating,
+/area/engineering/atmos)
+"xcq" = (
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "xdc" = (
 /obj/structure/table/reinforced,
@@ -56982,10 +56975,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
-"ygL" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "ygW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -57013,6 +57002,17 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"yhK" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "yhO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -68607,7 +68607,7 @@ cfN
 bWV
 bWV
 bWV
-oxd
+vBG
 cuS
 bWV
 bWV
@@ -70663,7 +70663,7 @@ cvy
 bWV
 cgG
 cgG
-oxd
+vBG
 cuY
 bWV
 cgG
@@ -74132,10 +74132,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+fon
+fon
+fon
+fon
 aaa
 aaa
 aaa
@@ -74388,12 +74388,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
+aht
+aht
+aht
+aht
+fon
 aaa
 aaa
 aaa
@@ -74643,15 +74643,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aht
+fon
+aht
 aOn
 aOn
 aOn
 aOn
-aaa
-aaa
+aht
+fon
 aaa
 aaa
 aaa
@@ -74900,15 +74900,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
+fon
 aaa
 aaa
 aOn
 fzz
 wOG
 aOn
-aaa
-aaa
+aht
+aht
 afU
 agi
 agi
@@ -75148,16 +75148,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+pDW
+pDW
+pDW
+pDW
+pDW
+pDW
+pDW
+pDW
+pDW
+fon
 aaa
 aaa
 aOn
@@ -75404,17 +75404,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
+aht
 aaa
 aaa
 aOn
@@ -75661,8 +75661,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+tna
+aht
 adE
 adE
 adE
@@ -75918,8 +75918,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+fon
+aht
 adE
 aeE
 ahG
@@ -76175,8 +76175,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+fon
+aht
 adE
 arl
 aij
@@ -76432,8 +76432,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+fon
+aht
 adE
 aeW
 aik
@@ -76689,8 +76689,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+fon
+aht
 adE
 aeX
 akN
@@ -76946,8 +76946,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+tna
+aht
 adE
 aeT
 akP
@@ -77203,8 +77203,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+fon
+aht
 adE
 afX
 alA
@@ -77460,8 +77460,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+fon
+aht
 adE
 adE
 adE
@@ -77718,8 +77718,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-pDW
+fon
+tna
 aht
 aem
 wPr
@@ -78746,7 +78746,7 @@ aaa
 aaa
 aaa
 aaa
-pDW
+tna
 aht
 ahC
 eTW
@@ -79794,7 +79794,7 @@ aem
 aem
 aem
 aem
-aaa
+aht
 aby
 abI
 ahL
@@ -80034,7 +80034,7 @@ aaa
 aaa
 aaa
 aaa
-pDW
+tna
 aht
 aem
 aem
@@ -80045,13 +80045,13 @@ aem
 aem
 aht
 pDW
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
+aht
+aht
+aht
+aht
+aht
+fon
 aby
 qLo
 ahL
@@ -80303,11 +80303,11 @@ aht
 aht
 pDW
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
+fon
+tna
+fon
+fon
 aaa
 aby
 abI
@@ -80810,8 +80810,8 @@ aaa
 pDW
 pDW
 pDW
-pDW
-pDW
+tna
+tna
 pDW
 pDW
 aaa
@@ -95838,11 +95838,11 @@ iiP
 iiP
 iiP
 xKM
-fOa
+hHP
 bMY
 bMY
 bMY
-ddi
+tyg
 fBp
 fBp
 fBp
@@ -96099,9 +96099,9 @@ sxs
 tlU
 bWO
 bWO
-epy
-ghv
-dkA
+eMy
+srz
+ugo
 xdQ
 aaa
 aaa
@@ -96352,13 +96352,13 @@ bYw
 bYw
 bYw
 bYw
-uTE
+hcI
 bWO
 bWO
-aia
-kpB
-ksp
-jvD
+anv
+vXu
+xcq
+sdb
 xdQ
 aaa
 aaa
@@ -96612,10 +96612,10 @@ cbC
 bUp
 bWO
 bWO
-gqc
-wYa
-wTA
-jvD
+dFV
+dUM
+mgY
+sdb
 xdQ
 aaa
 aaa
@@ -96869,10 +96869,10 @@ xTf
 bUp
 bWO
 bWO
-ksp
-jSY
-aia
-jvD
+xcq
+pYS
+anv
+sdb
 xdQ
 aaa
 aaa
@@ -97127,11 +97127,11 @@ bUp
 bWO
 bWO
 bWO
-ygL
+sZt
 bSh
-qXX
-htD
-iDb
+gKG
+iBo
+oAH
 aaa
 aaa
 fon
@@ -97380,11 +97380,11 @@ usl
 oib
 yjt
 cbC
-aMM
-net
-uTn
-gDs
-gDe
+yhK
+vSL
+trA
+ksU
+kHv
 fBp
 fBp
 fBp
@@ -97893,7 +97893,7 @@ cBd
 hqI
 klp
 njg
-uTz
+rsR
 rLJ
 gYo
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -11267,7 +11267,7 @@
 /obj/machinery/button/door/directional/east{
 	id = "Potty1";
 	name = "Bathroom Bolt Control";
-	specialfunctions = 4
+	normaldoorcontrol = 1
 	},
 /obj/machinery/light_switch/directional/east{
 	name = "Light Switch";
@@ -14669,19 +14669,17 @@
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aYO" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
+/obj/effect/turf_decal/tile/green,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aYP" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -14690,7 +14688,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aYR" = (
-/obj/machinery/vending/dinnerware,
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
@@ -14994,12 +14991,12 @@
 /area/service/bar/atrium)
 "bap" = (
 /obj/machinery/computer/slot_machine,
-/turf/open/floor/carpet/lone,
+/turf/open/floor/carpet/lone/star,
 /area/service/bar/atrium)
 "baq" = (
 /obj/effect/spawner/randomarcade,
 /obj/structure/noticeboard/directional/north,
-/turf/open/floor/carpet/lone,
+/turf/open/floor/carpet/lone/star,
 /area/service/bar/atrium)
 "bar" = (
 /obj/effect/turf_decal/tile/brown{
@@ -15318,16 +15315,16 @@
 "bbv" = (
 /obj/item/trash/can,
 /obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/carpet/lone,
+/turf/open/floor/carpet/lone/star,
 /area/service/bar/atrium)
 "bbw" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/carpet/lone,
+/turf/open/floor/carpet/lone/star,
 /area/service/bar/atrium)
 "bbx" = (
 /obj/structure/chair/stool/bar/directional/south,
-/turf/open/floor/carpet/lone,
+/turf/open/floor/carpet/lone/star,
 /area/service/bar/atrium)
 "bbA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -15752,26 +15749,31 @@
 /turf/open/floor/iron,
 /area/service/janitor)
 "bdj" = (
-/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bdk" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "bdl" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -32110,9 +32112,7 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cpA" = (
-/obj/machinery/computer/chef_order{
-	dir = 1
-	},
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "cpB" = (
@@ -38215,11 +38215,12 @@
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "gFw" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -47498,9 +47499,15 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "qih" = (
-/obj/machinery/holopad,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/computer/chef_order{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/service/kitchen/coldroom)
 "qit" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants{
@@ -48232,6 +48239,10 @@
 "qRW" = (
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
+"qTd" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/service/chapel/main/monastery)
 "qUe" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -68455,7 +68466,7 @@ cfN
 bWV
 bWV
 bWV
-bWV
+qTd
 cuS
 bWV
 bWV
@@ -70511,7 +70522,7 @@ cvy
 bWV
 cgG
 cgG
-bWV
+qTd
 cuY
 bWV
 cgG
@@ -85343,7 +85354,7 @@ afu
 pMM
 aTZ
 wsV
-iNR
+qih
 afu
 afu
 nRV
@@ -87417,7 +87428,7 @@ bjg
 fmD
 cpZ
 cqc
-qih
+ufo
 boL
 bja
 yat

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2298,6 +2298,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/execution/transfer)
+"aia" = (
+/obj/effect/turf_decal/bot/right,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aid" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11537,6 +11541,17 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"aMM" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "aMV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/artistic{
@@ -24100,18 +24115,16 @@
 /area/space/nearstation)
 "bGK" = (
 /obj/structure/closet/boxinggloves,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bGL" = (
 /obj/structure/closet/masks,
 /obj/item/food/deadmouse,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bGM" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/plating,
+/turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bGO" = (
 /obj/structure/disposalpipe/segment,
@@ -24629,6 +24642,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = 32
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bJi" = (
@@ -24892,6 +24906,7 @@
 /obj/structure/light_construct{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bKn" = (
@@ -24917,10 +24932,13 @@
 /turf/open/floor/carpet,
 /area/medical/psychology)
 "bKq" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/sign/warning/deathsposal,
-/turf/open/floor/plating,
-/area/medical/virology)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/duct,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "bKr" = (
 /obj/structure/bed/roller,
 /obj/effect/turf_decal/tile/blue{
@@ -25495,6 +25513,7 @@
 /area/maintenance/department/engine)
 "bMD" = (
 /obj/effect/decal/cleanable/oil,
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bME" = (
@@ -26149,16 +26168,16 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
 	},
+/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bPq" = (
-/obj/item/trash/chips,
+/obj/structure/table_frame,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bPr" = (
 /obj/structure/table,
-/obj/item/paper,
-/obj/item/pen,
+/obj/item/reagent_containers/glass/rag,
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "bPy" = (
@@ -27226,23 +27245,24 @@
 /turf/open/space,
 /area/space/nearstation)
 "bTa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/costume,
+/obj/effect/spawner/lootdrop/costume,
+/turf/open/floor/wood/parquet,
+/area/maintenance/department/engine)
 "bTb" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/machinery/duct,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/engine)
 "bTc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/reagent_dispensers/plumbed,
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
 "bTf" = (
@@ -27549,10 +27569,12 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "bTW" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/costume,
+/obj/effect/spawner/lootdrop/costume,
+/turf/open/floor/wood/parquet,
+/area/maintenance/department/engine)
 "bTX" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/structure/window/reinforced,
@@ -27729,24 +27751,19 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plating/asteroid,
 /area/service/chapel/asteroid/monastery)
-"bUD" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/space,
-/area/space/nearstation)
 "bUE" = (
-/obj/structure/lattice,
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/machinery/duct,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/department/engine)
 "bUF" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil,
-/obj/item/extinguisher,
+/obj/item/vending_refill/cola,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bUG" = (
@@ -28043,8 +28060,16 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "bVs" = (
-/obj/structure/mopbucket,
-/obj/item/mop,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "bVu" = (
@@ -29153,12 +29178,9 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "bZh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 1
-	},
+/obj/machinery/duct,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/maintenance/department/engine)
 "bZl" = (
 /obj/structure/chair/wood,
 /turf/open/floor/iron/chapel{
@@ -29173,9 +29195,7 @@
 /area/service/chapel/main/monastery)
 "bZr" = (
 /obj/item/trash/tray,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -32385,7 +32405,6 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cqy" = (
-/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
 "cqz" = (
@@ -32506,7 +32525,7 @@
 /area/service/chapel/asteroid/monastery)
 "crm" = (
 /obj/structure/lattice,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
 /turf/open/space,
 /area/space/nearstation)
 "crt" = (
@@ -32528,12 +32547,11 @@
 /turf/open/floor/iron/dark,
 /area/service/chapel/main/monastery)
 "cry" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/table,
+/obj/item/paper,
+/obj/item/pen,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "crz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -32541,17 +32559,11 @@
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "crA" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -32562,15 +32574,9 @@
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "crC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
@@ -34309,13 +34315,9 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "cRm" = (
-/obj/machinery/camera{
-	c_tag = "Atmos Hall";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/structure/chair/stool/bar/directional/east,
 /turf/open/floor/iron/dark,
-/area/engineering/atmos)
+/area/maintenance/department/engine)
 "cRA" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -34445,6 +34447,16 @@
 	},
 /turf/open/floor/iron,
 /area/command/gateway)
+"ddi" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "dej" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
@@ -34570,6 +34582,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/explab)
+"dkA" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "dkU" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/effect/landmark/start/prisoner,
@@ -35174,8 +35196,10 @@
 	},
 /area/service/abandoned_gambling_den)
 "dRB" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
+/obj/structure/table,
+/obj/item/storage/box/mousetraps,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/maintenance/department/engine)
 "dRU" = (
@@ -35603,6 +35627,12 @@
 /obj/machinery/light/no_nightlight/directional/west,
 /turf/open/floor/iron/freezer,
 /area/security/prison/toilet)
+"epy" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "epJ" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -35746,10 +35776,10 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "evU" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/plating,
-/area/engineering/atmos)
+/obj/structure/table,
+/obj/item/flashlight/lamp,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "ewb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
@@ -36930,13 +36960,12 @@
 /turf/open/floor/iron/dark,
 /area/science/server)
 "fwg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "fwi" = (
@@ -37258,13 +37287,12 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "fLO" = (
-/obj/machinery/door/airlock/atmos{
-	name = "HFR";
-	req_access_txt = "24"
+/obj/structure/mirror/directional/north,
+/obj/structure/sink{
+	pixel_y = 20
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating/airless,
-/area/engineering/atmos)
+/turf/open/floor/wood/parquet,
+/area/maintenance/department/engine)
 "fLV" = (
 /obj/machinery/computer/holodeck{
 	dir = 4
@@ -37323,6 +37351,21 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/psychology)
+"fOa" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "fOq" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/plating/asteroid,
@@ -37616,6 +37659,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/medical/virology)
+"ghv" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ghx" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -37826,6 +37879,12 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"gqc" = (
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gqx" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/structure/table,
@@ -38118,12 +38177,37 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/explab)
+"gDe" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gDq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
+"gDs" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "gDQ" = (
 /obj/machinery/door/poddoor/massdriver_trash,
 /obj/structure/fans/tiny,
@@ -38683,7 +38767,7 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "hiU" = (
-/turf/open/space/basic,
+/turf/open/floor/wood/parquet,
 /area/maintenance/department/engine)
 "hiY" = (
 /obj/machinery/navbeacon{
@@ -38862,6 +38946,11 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal/incinerator)
+"htD" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "htK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -38933,10 +39022,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"hwr" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall,
-/area/service/chapel/main/monastery)
 "hwx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -39016,16 +39101,16 @@
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
 "hBY" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp,
-/turf/open/floor/iron/dark,
+/obj/structure/mineral_door/wood{
+	name = "Dressing Room"
+	},
+/obj/machinery/duct,
+/turf/open/floor/wood/parquet,
 /area/maintenance/department/engine)
 "hCg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/obj/machinery/duct,
+/turf/open/floor/wood/parquet,
+/area/maintenance/department/engine)
 "hCj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -39402,8 +39487,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/department/engine)
+/area/space/nearstation)
 "hTw" = (
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
@@ -40013,6 +40099,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"iDb" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/engineering/atmos)
 "iDT" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -40301,20 +40394,10 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "iVT" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/wood/parquet,
+/area/maintenance/department/engine)
 "iWV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
 	dir = 8
@@ -40716,6 +40799,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"jvD" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "jwq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41039,6 +41129,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"jSY" = (
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "jTu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -41427,6 +41523,12 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/stairs/left,
 /area/service/abandoned_gambling_den)
+"kpB" = (
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "kqc" = (
 /obj/machinery/camera{
 	c_tag = "Incinerator";
@@ -41523,6 +41625,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/prison)
+"ksp" = (
+/obj/effect/turf_decal/bot/left,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ksv" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -41885,24 +41991,11 @@
 	},
 /area/maintenance/department/security/brig)
 "kJU" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "HFR Room"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"kKy" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/engineering/atmos)
+/obj/structure/table,
+/obj/item/stack/cable_coil,
+/obj/item/extinguisher,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "kKz" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -42980,16 +43073,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lTW" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/item/trash/chips,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "lUC" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -43450,15 +43536,12 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "mrH" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/structure/table_frame,
+/obj/item/stack/rods{
+	amount = 2
 	},
-/obj/structure/rack,
-/obj/item/hfr_box/corner,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "mrR" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
@@ -43493,16 +43576,19 @@
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
 "mtB" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/computer/arcade/orion_trail{
+	desc = "For gamers only. Casuals need not apply.";
+	icon_screen = "library";
+	icon_state = "oldcomp";
+	name = "Gamer Computer"
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/structure/rack,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "mtC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -43843,17 +43929,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/maintenance/department/engine)
+/area/space/nearstation)
 "mMd" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/medical/psychology)
 "mNv" = (
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
+/obj/structure/sink{
+	pixel_y = 20
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "mNN" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/command/glass{
@@ -44223,6 +44313,16 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"net" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/rack,
+/obj/item/hfr_box/corner,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nev" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -44995,11 +45095,13 @@
 /turf/closed/wall,
 /area/service/kitchen)
 "nSc" = (
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
+/obj/machinery/door/airlock/maintenance{
+	name = "Gamer Hideout"
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/effect/mapping_helpers/airlock/abandoned,
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "nSe" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -45665,11 +45767,8 @@
 /turf/open/floor/iron,
 /area/engineering/storage_shared)
 "ouv" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
-	dir = 4;
-	name = "Outlet injector"
-	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
+/turf/closed/wall,
 /area/maintenance/department/engine)
 "ovf" = (
 /obj/structure/window/reinforced,
@@ -45720,6 +45819,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"oxd" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/service/chapel/main/monastery)
 "oxC" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -45992,6 +46095,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -46871,6 +46975,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "pEK" = (
@@ -46936,9 +47041,12 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "pGV" = (
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/item/stack/sheet/cardboard{
+	amount = 14
+	},
+/obj/machinery/duct,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "pGZ" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern{
@@ -47531,19 +47639,11 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "qih" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/duct,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/area/maintenance/department/engine)
 "qit" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants{
@@ -47904,6 +48004,8 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "qvR" = (
@@ -48383,6 +48485,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
 /turf/closed/wall/r_wall,
 /area/engineering/lobby)
+"qXX" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qYn" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -48512,14 +48625,11 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "rjl" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "rka" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
@@ -48770,11 +48880,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rsy" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/chair/comfy{
+	dir = 1
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/structure/sign/poster/contraband/pwr_game{
+	pixel_x = -32
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "rsK" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/cleanable/dirt,
@@ -48997,11 +49111,10 @@
 /turf/open/floor/iron,
 /area/medical/cryo)
 "ryS" = (
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
+/obj/effect/decal/cleanable/vomit/old,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "rzp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -49920,9 +50033,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ssU" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "stc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/iron/white,
@@ -50066,11 +50183,13 @@
 	},
 /area/maintenance/department/security/brig)
 "syt" = (
-/obj/effect/turf_decal/box/white{
-	color = "#EFB341"
+/obj/structure/table,
+/obj/item/storage/box/drinkingglasses{
+	pixel_x = -4;
+	pixel_y = 4
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "syA" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
@@ -50437,9 +50556,9 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "sQP" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/vending/boozeomat,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "sSj" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/south,
@@ -51671,16 +51790,10 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "tSV" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/table/reinforced,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/structure/table,
+/obj/structure/frame/machine,
+/turf/open/floor/iron/dark,
+/area/maintenance/department/engine)
 "tTq" = (
 /obj/structure/closet/crate,
 /obj/item/food/breadslice/plain,
@@ -52268,15 +52381,13 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "uqf" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/light/directional/west,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/area/maintenance/department/engine)
 "uqs" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/grass,
@@ -52937,6 +53048,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"uTn" = (
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/rack,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uTt" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
@@ -52949,6 +53071,24 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"uTz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
+"uTE" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "HFR Room"
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uTI" = (
@@ -53063,13 +53203,11 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "uWA" = (
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/arrows/white{
-	color = "#0000FF";
-	pixel_y = 15
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/structure/rack,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/plating/airless,
+/area/maintenance/department/engine)
 "uWC" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53387,10 +53525,10 @@
 	},
 /area/maintenance/department/security/brig)
 "viB" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/structure/sign/warning/deathsposal{
-	pixel_x = -32
+/obj/machinery/door/airlock/maintenance{
+	name = "Custodial Closet"
 	},
+/obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "vjH" = (
@@ -54495,15 +54633,15 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "wjT" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/area/maintenance/department/engine)
 "wkA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -54550,10 +54688,8 @@
 /turf/open/floor/iron/white,
 /area/science/xenobiology)
 "wlc" = (
-/obj/structure/table,
-/obj/item/storage/box/mousetraps,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/brown/visible/layer2,
+/obj/structure/mopbucket,
+/obj/item/mop,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wlr" = (
@@ -54672,6 +54808,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wsC" = (
@@ -54747,6 +54884,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "wwr" = (
@@ -55172,11 +55310,12 @@
 /turf/open/space,
 /area/space/nearstation)
 "wMm" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Atmos Hall";
+	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "wMn" = (
 /obj/structure/window/reinforced/spawner/east,
@@ -55350,6 +55489,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"wTA" = (
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/arrows/white{
+	color = "#0000FF";
+	pixel_y = 15
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wTD" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -55508,6 +55655,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/supermatter)
+"wYa" = (
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wYi" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
 	dir = 4
@@ -56405,16 +56556,13 @@
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "xJb" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/lattice,
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
+	dir = 4;
+	name = "Outlet injector"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/turf/open/space/basic,
+/area/maintenance/department/engine)
 "xJy" = (
 /obj/structure/chair/comfy/black,
 /obj/structure/sign/plaques/kiddie{
@@ -56441,15 +56589,10 @@
 	},
 /area/maintenance/department/engine)
 "xKM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/vending_refill/cola,
-/obj/item/stack/sheet/cardboard{
-	amount = 14
-	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/plating,
-/area/maintenance/department/engine)
+/area/engineering/atmos)
 "xLi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -56626,9 +56769,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "xTf" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/atmos{
+	name = "HFR";
+	req_access_txt = "24"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating/airless,
 /area/engineering/atmos)
 "xTi" = (
 /obj/machinery/conveyor{
@@ -56836,6 +56982,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"ygL" = (
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "ygW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -68457,7 +68607,7 @@ cfN
 bWV
 bWV
 bWV
-hwr
+oxd
 cuS
 bWV
 bWV
@@ -70513,7 +70663,7 @@ cvy
 bWV
 cgG
 cgG
-hwr
+oxd
 cuY
 bWV
 cgG
@@ -75115,10 +75265,10 @@ aht
 aht
 aht
 aht
-aht
-aht
-aht
-aht
+bva
+bva
+bva
+bva
 aht
 abI
 abI
@@ -75371,12 +75521,12 @@ amB
 aaa
 aht
 aaa
-aaa
-aaa
-aht
-aht
-aaa
-aaa
+bIZ
+bIZ
+cry
+evU
+bIZ
+bIZ
 aaa
 aaa
 aht
@@ -75629,10 +75779,10 @@ aht
 aht
 bva
 bIZ
-bIZ
-bva
-bva
-bIZ
+bHQ
+cRm
+bHQ
+bHQ
 bIZ
 bva
 fon
@@ -75888,7 +76038,7 @@ bva
 bJa
 bHQ
 bLt
-hBY
+bHQ
 bNF
 bHQ
 bva
@@ -76150,7 +76300,7 @@ oWL
 bHQ
 bPp
 bva
-aaa
+bva
 aaa
 aht
 cdm
@@ -76405,10 +76555,10 @@ bLu
 bLu
 bNG
 bOz
+lTW
 bHQ
 bIZ
-aht
-aht
+bIZ
 aht
 cdm
 aht
@@ -76663,9 +76813,9 @@ bMA
 bNH
 bOz
 bHQ
+bHQ
+mrH
 bIZ
-aht
-aht
 aht
 cdm
 aht
@@ -76920,9 +77070,9 @@ bMB
 bNI
 bOz
 bHQ
+bHQ
+syt
 bIZ
-aaa
-aaa
 aht
 cdm
 aht
@@ -77176,10 +77326,10 @@ bLx
 bLx
 bNJ
 bOz
+mrH
 bHQ
+sQP
 bIZ
-aaa
-aaa
 aht
 cdm
 aht
@@ -77434,9 +77584,9 @@ bMC
 eHb
 bHQ
 bPq
+bHQ
+tSV
 bva
-aht
-aht
 aht
 cdm
 aht
@@ -77683,17 +77833,17 @@ bva
 bva
 oTJ
 bHQ
-kjI
+bKq
 bJh
-bHQ
+bZh
 bKm
 bMD
-bHQ
+bZh
 bOA
 bPr
+bHQ
+tSV
 bva
-aht
-aht
 aht
 cdm
 aht
@@ -77945,12 +78095,12 @@ bva
 bva
 bva
 bva
-bIZ
-bIZ
+hBY
 bva
 bva
-aht
-aaa
+bva
+bva
+bva
 aht
 cdm
 abI
@@ -78197,18 +78347,18 @@ bNQ
 xtI
 xtI
 xtI
-olY
+dEa
 bDi
 mpU
-bIZ
-aaa
-aaa
-aht
-aaa
-aaa
-aht
-aaa
-aht
+bva
+fLO
+hCg
+bva
+mtB
+rsy
+bDi
+bva
+xJb
 cdm
 abI
 aaa
@@ -78454,19 +78604,19 @@ bEr
 bEr
 bAW
 bva
-kkF
+bTb
 bDi
 lrI
-bIZ
-aaa
-aaa
-bUD
-cqX
-cqX
-cqX
-cqX
+bva
+hiU
+iVT
+ouv
+mNv
+ryS
+uqf
+ouv
 crm
-cry
+ahi
 abI
 aaa
 bIZ
@@ -78711,17 +78861,17 @@ bNL
 bOD
 aht
 bIZ
-olY
+dEa
 bDi
 ccN
 bva
 bTa
 bTW
-bUE
-aaa
-abI
-aaa
-aaa
+bva
+nSc
+bva
+bva
+bva
 bva
 crz
 bva
@@ -78968,18 +79118,18 @@ bNM
 bOD
 aht
 bIZ
-olY
+dEa
 bDi
 ftp
 bva
-bTb
+bva
 ouv
-bIZ
-bIZ
 bva
+pGV
 bva
-aht
-bIZ
+uWA
+bVC
+bva
 crA
 bIZ
 aaa
@@ -79225,17 +79375,17 @@ bKn
 bEr
 aht
 bva
-tAh
+bUE
 bWZ
 fVi
 bva
 bTc
 dRB
-bIZ
-bVs
+kJU
+sqG
 viB
 cqy
-aaa
+wlc
 bva
 crB
 bva
@@ -79486,10 +79636,10 @@ pEv
 bRD
 qpT
 bSo
-xKM
-wlc
+sqG
+isF
 bUF
-bNK
+qih
 bva
 bva
 bva
@@ -79739,18 +79889,18 @@ vmY
 hnY
 aKl
 ctF
-cFT
-bDi
+bVs
+sqG
 wwp
 oKD
 fwg
 qvM
-iFA
-iFA
-iFA
-bWZ
-iFA
-bDi
+fwg
+fwg
+ssU
+wjT
+ssU
+bRD
 bZr
 caa
 caa
@@ -79989,7 +80139,7 @@ sEN
 sEN
 sEN
 und
-bKq
+bKn
 bKn
 bEr
 bEr
@@ -82837,12 +82987,12 @@ cad
 eYM
 bQl
 mMc
-hiU
-hiU
-hiU
-mZE
-mZE
-mZE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -83094,12 +83244,12 @@ gMO
 kCc
 bva
 hTr
-hiU
-hiU
-mZE
-mZE
-mZE
-mZE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95680,19 +95830,19 @@ auW
 tvr
 axx
 bRn
-bZh
-iiP
-iiP
-cRm
-iiP
-iiP
-iiP
-evU
-iVT
-bMY
-bMY
-bMY
 rjl
+iiP
+iiP
+wMm
+iiP
+iiP
+iiP
+xKM
+fOa
+bMY
+bMY
+bMY
+ddi
 fBp
 fBp
 fBp
@@ -95949,9 +96099,9 @@ sxs
 tlU
 bWO
 bWO
-rsy
-uqf
-wjT
+epy
+ghv
+dkA
 xdQ
 aaa
 aaa
@@ -96202,13 +96352,13 @@ bYw
 bYw
 bYw
 bYw
-kJU
+uTE
 bWO
 bWO
-mNv
-ryS
-pGV
-wMm
+aia
+kpB
+ksp
+jvD
 xdQ
 aaa
 aaa
@@ -96462,10 +96612,10 @@ cbC
 bUp
 bWO
 bWO
-nSc
-ssU
-uWA
-wMm
+gqc
+wYa
+wTA
+jvD
 xdQ
 aaa
 aaa
@@ -96715,14 +96865,14 @@ usl
 usl
 jKs
 yjt
-fLO
+xTf
 bUp
 bWO
 bWO
-pGV
-syt
-mNv
-wMm
+ksp
+jSY
+aia
+jvD
 xdQ
 aaa
 aaa
@@ -96977,11 +97127,11 @@ bUp
 bWO
 bWO
 bWO
-sQP
+ygL
 bSh
-xJb
-xTf
-kKy
+qXX
+htD
+iDb
 aaa
 aaa
 fon
@@ -97230,11 +97380,11 @@ usl
 oib
 yjt
 cbC
-lTW
-mrH
-mtB
-qih
-tSV
+aMM
+net
+uTn
+gDs
+gDe
 fBp
 fBp
 fBp
@@ -97743,7 +97893,7 @@ cBd
 hqI
 klp
 njg
-hCg
+uTz
 rLJ
 gYo
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -6487,9 +6487,15 @@
 /turf/closed/wall,
 /area/command/heads_quarters/captain)
 "auI" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/computer/chef_order{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/service/kitchen/coldroom)
 "auJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -7484,6 +7490,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/navbeacon/wayfinding/incinerator,
+/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "axy" = (
@@ -7756,15 +7763,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ayG" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/machinery/smartfridge/chemistry/preloaded,
+/turf/closed/wall,
+/area/medical/chemistry)
 "ayI" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=BrigS2";
@@ -7980,9 +7981,22 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "azm" = (
-/obj/effect/turf_decal/bot/right,
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/light/directional/east,
+/obj/structure/table/glass,
+/obj/item/stack/ducts/fifty{
+	pixel_y = 5
+	},
+/obj/item/stack/ducts/fifty{
+	pixel_y = 7
+	},
+/obj/item/construction/plumbing,
+/obj/item/construction/plumbing,
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "azo" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -8022,10 +8036,10 @@
 /turf/open/floor/carpet,
 /area/commons/dorms)
 "azt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
 	},
-/turf/open/floor/iron/dark,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "azu" = (
 /obj/machinery/door/airlock{
@@ -8080,11 +8094,23 @@
 /turf/open/space,
 /area/solars/port)
 "azN" = (
-/obj/effect/turf_decal/box/white{
-	color = "#52B4E9"
+/obj/machinery/button/door/directional/north{
+	id = "chemistry_shutters";
+	name = "Shutters Control";
+	pixel_x = -5
 	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/table/glass,
+/obj/item/hand_labeler,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "azR" = (
 /obj/machinery/door/airlock/command{
 	id_tag = "CMOCell";
@@ -18964,8 +18990,14 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bpX" = (
-/obj/machinery/smartfridge/chemistry/preloaded,
-/turf/closed/wall,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/structure/table/glass,
+/obj/item/stack/cable_coil,
+/obj/item/storage/box/beakers,
+/turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bpY" = (
 /turf/closed/wall,
@@ -19466,14 +19498,8 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
-	},
-/obj/machinery/button/door/directional/east{
-	id = "chemistry_shutters";
-	name = "Shutters Control";
-	req_access_txt = "33"
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -19956,6 +19982,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bsJ" = (
@@ -19986,10 +20013,6 @@
 "bsN" = (
 /obj/machinery/chem_dispenser{
 	layer = 2.7
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
@@ -21019,24 +21042,14 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/table/glass,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/clothing/head/welding,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bwT" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/table/glass,
-/obj/item/hand_labeler,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bwV" = (
@@ -21579,20 +21592,10 @@
 /area/medical/chemistry)
 "byw" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/table/glass,
-/obj/item/stack/ducts/fifty{
-	pixel_y = 7
-	},
-/obj/item/stack/ducts/fifty{
-	pixel_y = 5
-	},
-/obj/item/construction/plumbing,
-/obj/item/construction/plumbing,
+/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "byz" = (
@@ -22136,15 +22139,7 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bAe" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/item/stack/cable_coil,
-/obj/item/storage/box/beakers,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/structure/table/glass,
+/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bAg" = (
@@ -22836,6 +22831,9 @@
 	dir = 1
 	},
 /obj/machinery/chem_heater/withbuffer,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bCt" = (
@@ -22846,17 +22844,14 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bCv" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/chem_heater/withbuffer,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bCx" = (
+/obj/effect/turf_decal/trimline/yellow/line,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bCE" = (
@@ -29158,8 +29153,10 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "bZh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/obj/machinery/light/directional/west,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "bZl" = (
@@ -34312,6 +34309,10 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "cRm" = (
+/obj/machinery/camera{
+	c_tag = "Atmos Hall";
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
@@ -34448,7 +34449,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
-/turf/open/floor/iron/dark,
+/turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "dfm" = (
 /obj/effect/turf_decal/tile/purple,
@@ -35745,8 +35746,9 @@
 /turf/open/floor/iron/white,
 /area/security/prison)
 "evU" = (
-/obj/effect/turf_decal/bot/left,
-/turf/open/floor/iron,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "ewb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -37256,10 +37258,13 @@
 /turf/open/floor/iron/white/corner,
 /area/hallway/secondary/entry)
 "fLO" = (
-/obj/effect/turf_decal/trimline/yellow/line,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
+/obj/machinery/door/airlock/atmos{
+	name = "HFR";
+	req_access_txt = "24"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating/airless,
+/area/engineering/atmos)
 "fLV" = (
 /obj/machinery/computer/holodeck{
 	dir = 4
@@ -38928,6 +38933,10 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"hwr" = (
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/service/chapel/main/monastery)
 "hwx" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -39012,15 +39021,11 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/department/engine)
 "hCg" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "hCj" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
@@ -39695,11 +39700,7 @@
 /turf/open/floor/iron/dark,
 /area/service/library/artgallery)
 "iiP" = (
-/obj/machinery/door/airlock/atmos{
-	name = "HFR";
-	req_access_txt = "24"
-	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos)
 "ijU" = (
@@ -40300,9 +40301,19 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "iVT" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/iron,
 /area/engineering/atmos)
 "iWV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2{
@@ -40970,8 +40981,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 5
 	},
-/turf/closed/wall/r_wall,
-/area/engineering/atmos)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jOw" = (
 /obj/structure/table/wood/fancy,
 /obj/structure/sign/painting/library_secure{
@@ -41805,6 +41817,12 @@
 /obj/machinery/light_switch/directional/north{
 	name = "Light Switch"
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "kGE" = (
@@ -41868,15 +41886,22 @@
 /area/maintenance/department/security/brig)
 "kJU" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/camera{
+	c_tag = "HFR Room"
+	},
 /turf/open/floor/iron,
+/area/engineering/atmos)
+"kKy" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1
+	},
+/turf/open/space/basic,
 /area/engineering/atmos)
 "kKz" = (
 /obj/structure/window/reinforced{
@@ -42554,13 +42579,13 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/keycard_auth{
-	pixel_x = 26
-	},
 /obj/machinery/button/door/directional/east{
 	id = "cmoprivacy";
 	name = "CMO Shutter Control";
 	req_access_txt = "40"
+	},
+/obj/machinery/keycard_auth/directional/east{
+	pixel_y = 10
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/cmo)
@@ -42955,8 +42980,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "lTW" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/closet/radiation,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "lUC" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -43417,13 +43450,13 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "mrH" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/obj/structure/rack,
+/obj/item/hfr_box/corner,
+/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mrR" = (
@@ -43460,9 +43493,16 @@
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
 "mtB" = (
-/obj/structure/sign/warning/biohazard,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/airalarm/directional/east,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/structure/rack,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "mtC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -43811,15 +43851,7 @@
 /turf/open/floor/grass,
 /area/medical/psychology)
 "mNv" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot/right,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "mNN" = (
@@ -44963,9 +44995,11 @@
 /turf/closed/wall,
 /area/service/kitchen)
 "nSc" = (
-/obj/structure/grille,
-/turf/open/space,
-/area/space)
+/obj/effect/turf_decal/box/white{
+	color = "#9FED58"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "nSe" = (
 /obj/structure/cable,
 /turf/open/floor/iron,
@@ -46902,9 +46936,7 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "pGV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/effect/turf_decal/bot/left,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "pGZ" = (
@@ -47499,15 +47531,19 @@
 /turf/open/floor/iron,
 /area/medical/medbay/central)
 "qih" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/computer/chef_order{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/stack/cable_coil{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/service/kitchen/coldroom)
+/obj/item/stack/sheet/plasteel/fifty,
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "qit" = (
 /obj/structure/table/wood,
 /obj/item/kirbyplants{
@@ -47757,8 +47793,9 @@
 	dir = 1
 	},
 /obj/structure/table/glass,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
+/obj/item/stack/sheet/iron/fifty,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/clothing/head/welding,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "qqZ" = (
@@ -48239,10 +48276,6 @@
 "qRW" = (
 /turf/open/floor/wood,
 /area/service/abandoned_gambling_den)
-"qTd" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall,
-/area/service/chapel/main/monastery)
 "qUe" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -48443,24 +48476,6 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"rfm" = (
-/obj/structure/rack,
-/obj/item/hfr_box/body/fuel_input,
-/obj/item/hfr_box/body/interface,
-/obj/item/hfr_box/body/moderator_input,
-/obj/item/hfr_box/body/waste_output,
-/obj/item/hfr_box/core,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/item/hfr_box/corner,
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "rgs" = (
 /obj/structure/table,
 /obj/item/instrument/eguitar,
@@ -48497,7 +48512,13 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "rjl" = (
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rka" = (
@@ -48749,8 +48770,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "rsy" = (
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -48976,9 +48997,11 @@
 /turf/open/floor/iron,
 /area/medical/cryo)
 "ryS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
-/area/maintenance/disposal/incinerator)
+/obj/effect/turf_decal/box/white{
+	color = "#52B4E9"
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "rzp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
@@ -49156,8 +49179,10 @@
 /turf/open/floor/plating,
 /area/engineering/atmos)
 "rGD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
-/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 5
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "rHh" = (
@@ -49895,9 +49920,7 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ssU" = (
-/obj/effect/turf_decal/box/white{
-	color = "#EFB341"
-	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "stc" = (
@@ -50014,17 +50037,14 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "sxs" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/iron/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/airalarm/directional/east,
-/obj/machinery/camera{
-	c_tag = "HFR Room";
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -50046,10 +50066,8 @@
 	},
 /area/maintenance/department/security/brig)
 "syt" = (
-/obj/effect/turf_decal/box/white,
-/obj/effect/turf_decal/arrows/white{
-	color = "#0000FF";
-	pixel_y = 15
+/obj/effect/turf_decal/box/white{
+	color = "#EFB341"
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -50419,8 +50437,9 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "sQP" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "sSj" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/south,
@@ -50973,18 +50992,9 @@
 /turf/open/floor/plating,
 /area/engineering/supermatter/room)
 "tlU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/item/stack/sheet/plasteel/fifty,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tna" = (
@@ -51663,11 +51673,12 @@
 "tSV" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1
+	dir = 8
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "tTq" = (
@@ -52258,14 +52269,14 @@
 /area/engineering/supermatter/room)
 "uqf" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "uqs" = (
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/grass,
@@ -53052,9 +53063,10 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter/room)
 "uWA" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/box/white,
+/obj/effect/turf_decal/arrows/white{
+	color = "#0000FF";
+	pixel_y = 15
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -54348,14 +54360,6 @@
 /obj/structure/ore_box,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"wfp" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
-/turf/open/floor/iron,
-/area/engineering/atmos)
 "wfr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4{
 	dir = 4
@@ -54491,10 +54495,15 @@
 /turf/open/floor/iron/white,
 /area/science/genetics)
 "wjT" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space,
-/area/space)
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
 "wkA" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -55167,9 +55176,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wMn" = (
@@ -55276,11 +55282,6 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psychology)
-"wQE" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
-/turf/open/floor/plating,
-/area/engineering/atmos)
 "wQU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable,
@@ -55663,11 +55664,8 @@
 /turf/open/floor/iron,
 /area/science/xenobiology)
 "xdQ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 1
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engineering/atmos)
 "xdY" = (
 /obj/machinery/door/window/eastright{
@@ -56407,12 +56405,14 @@
 /turf/open/floor/iron/white,
 /area/medical/paramedic)
 "xJb" = (
+/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
-	dir = 1
+	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "xJy" = (
@@ -56626,19 +56626,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "xTf" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers,
+/turf/open/floor/plating,
+/area/engineering/atmos)
 "xTi" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -68466,7 +68457,7 @@ cfN
 bWV
 bWV
 bWV
-qTd
+hwr
 cuS
 bWV
 bWV
@@ -70522,7 +70513,7 @@ cvy
 bWV
 cgG
 cgG
-qTd
+hwr
 cuY
 bWV
 cgG
@@ -85354,7 +85345,7 @@ afu
 pMM
 aTZ
 wsV
-qih
+auI
 afu
 afu
 nRV
@@ -86155,7 +86146,7 @@ bpV
 bzZ
 bBg
 bCr
-iTx
+bCx
 tta
 uXp
 xqq
@@ -86665,7 +86656,7 @@ frX
 dRU
 gzG
 brh
-bpX
+bpV
 brl
 bBi
 bCt
@@ -87178,7 +87169,7 @@ bsI
 mZi
 wEl
 bvp
-xTf
+brh
 bpV
 brm
 bsN
@@ -87431,16 +87422,16 @@ cqc
 ufo
 boL
 bja
-yat
+bja
 qnJ
 bja
 bja
+ayG
 bpY
-bpY
-bpY
-bpY
-bpY
-fLO
+azN
+bwT
+bAe
+iTx
 prD
 oBP
 xqq
@@ -87693,10 +87684,10 @@ bsJ
 buj
 bja
 bwS
-byw
-bAe
-uqf
-bCx
+uIo
+dcN
+bsK
+bsK
 iTx
 bLM
 wNG
@@ -87949,7 +87940,7 @@ fgs
 xmg
 buk
 bja
-bwT
+gFf
 bsK
 bsK
 bsK
@@ -88207,9 +88198,9 @@ bsL
 bul
 bja
 qqX
-mqg
-qwJ
-qwJ
+azm
+bpX
+byw
 qwJ
 bDy
 rIm
@@ -93895,22 +93886,22 @@ bJP
 bJP
 bJP
 bJP
-fBp
-auI
-auI
-auI
-auI
-auI
-fBp
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+fon
 aaa
 aaa
 aaa
+aht
+aaa
+aaa
+aaa
+aaa
+fon
 aaa
 aaa
 aaa
@@ -94152,22 +94143,22 @@ gGn
 cby
 cby
 bJP
-auI
-kJU
-xJb
-xJb
-xJb
-tSV
-auI
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+fon
 aaa
 aaa
 aaa
+fon
+aaa
+aaa
+aaa
+aaa
+fon
 aaa
 aaa
 aaa
@@ -94409,22 +94400,22 @@ cbx
 cco
 lag
 bJP
-auI
-bUp
-azm
-azN
-evU
-uWA
-auI
+aaa
+aaa
+aaa
+fon
+aht
+fon
+fon
+aht
+aht
+aaa
+fon
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tna
 aaa
 aaa
 aaa
@@ -94666,22 +94657,22 @@ oCb
 cby
 cby
 bJP
-auI
-bUp
-rsy
-rjl
-syt
-uWA
-auI
+aaa
+aaa
+aaa
+fon
 aaa
 aaa
 aaa
 aaa
+aht
+aaa
+fon
 aaa
 aaa
-aaa
-aaa
-aaa
+aht
+tna
+fon
 aaa
 aaa
 aaa
@@ -94923,20 +94914,20 @@ bJP
 bJP
 bJP
 bJP
-auI
-bUp
-evU
-ssU
-azm
-uWA
-auI
+aht
+fon
+fon
+fon
 aaa
 aaa
 aaa
 aaa
+aht
+aaa
+aht
 aaa
 aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -95175,18 +95166,6 @@ bWO
 bYt
 bZf
 jOl
-fBp
-fBp
-fBp
-fBp
-fBp
-fBp
-ayG
-bWO
-bWO
-bWO
-hCg
-auI
 aaa
 aaa
 aaa
@@ -95194,6 +95173,18 @@ aaa
 aaa
 aaa
 aaa
+aht
+aaa
+aaa
+aaa
+aaa
+aaa
+fon
+fon
+fon
+aaa
+aaa
+fon
 aaa
 aaa
 aaa
@@ -95433,24 +95424,24 @@ bYu
 tiG
 dej
 azt
-bZh
-cRm
-cRm
-cRm
-iVT
-mrH
-pGV
-bWO
-bWO
-wfp
-wQE
+fBp
+fBp
+fBp
+fBp
+fBp
+fBp
+fBp
 xdQ
+xdQ
+xdQ
+xdQ
+xdQ
+fBp
+aaa
+aht
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -95689,26 +95680,26 @@ auW
 tvr
 axx
 bRn
-dFK
-yeD
-yeD
-yeD
-yeD
+bZh
 iiP
-bUp
-bWO
-bWO
-bWO
-uWA
-auI
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+iiP
+cRm
+iiP
+iiP
+iiP
+evU
+iVT
+bMY
+bMY
+bMY
+rjl
+fBp
+fBp
+fBp
+aht
+aht
+fon
+fon
 aaa
 aaa
 aaa
@@ -95951,21 +95942,21 @@ yeD
 yeD
 yeD
 yeD
-mkf
-mNv
-rfm
+yeD
+yeD
+xdQ
 sxs
 tlU
-wMm
-auI
+bWO
+bWO
+rsy
+uqf
+wjT
+xdQ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -96211,18 +96202,18 @@ bYw
 bYw
 bYw
 bYw
-fBp
-fBp
-fBp
-fBp
+kJU
+bWO
+bWO
+mNv
+ryS
+pGV
+wMm
+xdQ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -96467,19 +96458,19 @@ fsO
 hnV
 tQj
 mPP
-ryS
+cbC
+bUp
+bWO
+bWO
+nSc
+ssU
+uWA
+wMm
+xdQ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -96724,19 +96715,19 @@ usl
 usl
 jKs
 yjt
-bYw
+fLO
+bUp
+bWO
+bWO
+pGV
+syt
+mNv
+wMm
+xdQ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -96982,18 +96973,18 @@ usl
 oib
 mYX
 bYw
+bUp
+bWO
+bWO
+bWO
+sQP
+bSh
+xJb
+xTf
+kKy
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -97238,19 +97229,19 @@ atF
 usl
 oib
 yjt
-bYw
+cbC
+lTW
+mrH
+mtB
+qih
+tSV
+fBp
+fBp
+fBp
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tna
 aaa
 aaa
 aaa
@@ -97496,18 +97487,18 @@ ccs
 axO
 uhR
 rGD
-rLJ
+mkf
+fBp
+fBp
+fBp
+xdQ
+fBp
+aaa
+aht
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
 aaa
 aaa
 aaa
@@ -97752,19 +97743,19 @@ cBd
 hqI
 klp
 njg
-bYw
-aaa
+hCg
+rLJ
 gYo
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+tna
+fon
+fon
+aht
+aht
 aaa
 cju
 cju
@@ -97999,7 +97990,7 @@ aby
 aby
 aby
 aby
-wjT
+aby
 aaa
 bYw
 aqB
@@ -98012,10 +98003,10 @@ azC
 bYw
 aht
 fon
-aaa
-aaa
-aaa
-aaa
+fon
+fon
+tna
+aht
 aaa
 aaa
 aaa
@@ -98512,7 +98503,7 @@ aby
 aaa
 acO
 aby
-nSc
+bSg
 aaa
 aaa
 aht
@@ -99286,7 +99277,7 @@ aaa
 aaa
 aaa
 aaa
-mZE
+aht
 aaa
 bYw
 xCh
@@ -109530,15 +109521,15 @@ aaa
 aaa
 aaa
 aaa
-sQP
-lTW
-sQP
-mtB
-lTW
-mtB
-sQP
-lTW
-sQP
+bkF
+bkF
+bkF
+xKc
+bkF
+xKc
+bkF
+bkF
+bkF
 aaa
 aby
 aaa


### PR DESCRIPTION
Not sure if I got everything, but this is whats been changed:

HFR
Moved the room to be connected to the turbine. 
![image](https://user-images.githubusercontent.com/70232195/128381662-9e51d0c7-a104-42ad-bdfe-a548f7442fb1.png)

Xenobio
Turf was missing
![image](https://user-images.githubusercontent.com/70232195/128381725-0367283c-4237-43ee-af41-242d8c506fd9.png)

Maint
Redid the wage cage a bit, spiffied it up. Hopefully I didn't break the disposals chute.
![image](https://user-images.githubusercontent.com/70232195/128381838-199311d0-725b-466d-ae0a-3be5b081b360.png)

Misc
Added some meteor shielding because holy shit does Pubby not have it.
![image](https://user-images.githubusercontent.com/70232195/128381890-c85c2fb9-05c5-4eeb-918d-896642b05c74.png)
![image](https://user-images.githubusercontent.com/70232195/128381937-cb80905d-3b53-4c2a-a641-3927794ba98b.png)
