### PR TITLE
Merge Driver Update

### DIFF
--- a/_merge_driver.bash
+++ b/_merge_driver.bash
@@ -2,7 +2,7 @@
 
 # print all files that aren't ticked in tgstation.dme
 #
-# supply one argument: the directorly to search
+# supply one argument: the directory to search
 find_unticked_files (){
 
 	if [ ! -d $1 ]; then
@@ -53,7 +53,7 @@ find_unticked_files (){
 # find all files with merge conflicts in the supplied directory
 # if no non-module comments are present, automatically resolve the merge conflict (accept incoming)
 #
-# supply one argument: the directorly to search
+# supply one argument: the directory to search
 find_all_in_dir (){
 
 	if [ ! -d $1 ]; then

--- a/_merge_driver.bash
+++ b/_merge_driver.bash
@@ -1,5 +1,59 @@
 #!/bin/bash
 
+# print all files that aren't ticked in tgstation.dme
+#
+# supply one argument: the directorly to search
+find_unticked_files (){
+
+	if [ ! -d $1 ]; then
+		echo "!! find_unticked_files error: $1 directory not found."
+		return 1
+	fi
+
+	NEED_NEWLINE=1
+	NUM_DOTS=0
+	for file in $(find $1 -name "*.dm" -or -name "*.js" -type f); do
+		if [ ! -f $file ]; then
+			continue
+		fi
+
+		if grep -q "/datum/unit_test" $file; then # Unit tests are not ticked
+			continue
+		fi
+		if grep -q "/datum/tgs_api" $file; then # TGS are not ticked either (I think)
+			continue
+		fi
+
+		FILE_NAME="$(echo $file | sed -e 's,/,\\,g')"
+		if ! grep -q -i -F "$FILE_NAME" tgstation.dme; then
+			if [ "$NEED_NEWLINE" -eq "1" ]; then
+				echo ""
+				NEED_NEWLINE=0
+			fi
+			echo "$FILE_NAME was found to not be in tgstation.dme / unticked!"
+			NUM_DOTS=0
+		else
+			NEED_NEWLINE=1
+			let NUM_DOTS++
+			if ! (($NUM_DOTS % 3)); then
+				echo -ne "."
+			fi
+			if [ "$NUM_DOTS" -ge "270" ]; then
+				echo ""
+				NUM_DOTS=0
+			fi
+		fi
+
+	done
+	echo ""
+	echo "Done search dir and all subdirs: $1."
+	return 0
+}
+
+# find all files with merge conflicts in the supplied directory
+# if no non-module comments are present, automatically resolve the merge conflict (accept incoming)
+#
+# supply one argument: the directorly to search
 find_all_in_dir (){
 
 	if [ ! -d $1 ]; then
@@ -13,9 +67,30 @@ find_all_in_dir (){
 		fi
 	done
 
+	NEED_NEWLINE=1
+	NUM_DOTS=0
 	for file in $(find $1 -name "*.dm" -or -name "*.js" -type f); do
-		if ! grep -q "<<<<<<<" "$file"; then
+		if [ ! -f $file ]; then
 			continue
+		fi
+
+		if ! grep -q "<<<<<<<" "$file"; then
+			NEED_NEWLINE=1
+			let NUM_DOTS++
+			if ! (($NUM_DOTS % 3)); then
+				echo -ne "."
+			fi
+			if [ "$NUM_DOTS" -ge "270" ]; then
+				echo ""
+				NUM_DOTS=0
+			fi
+			continue
+		fi
+
+		if [ "$NEED_NEWLINE" -eq "1" ]; then
+			echo ""
+			NEED_NEWLINE=0
+			NUM_DOTS=0
 		fi
 
 		if grep -q -i -E "\/{2,}\s*non(\s|-)*module" "$file"; then
@@ -28,10 +103,14 @@ find_all_in_dir (){
 		echo "$file merge conflicts resolved."
 	done
 
-	echo "Done searching dir: $1."
+	echo ""
+	echo "Done resolving dir and all subdirs: $1."
 	return 0
 }
 
+# updates the DME to the new version
+#
+# supply two arguments: the new tgstation.dme, and the old jollystation.dme
 update_dme (){
 
 	if [ ! -f $1 ]; then
@@ -60,16 +139,27 @@ update_dme (){
 	return 0
 }
 
+#update the build file
 update_build (){
 	sed -i 's/tgstation/jollystation/g' tools/build/build.js
 	return 0
 }
 
 echo "Running merge driver. . ."
+echo "====================================================================================="
+echo "Looking for unticked files. . ."
+find_unticked_files "code"
+echo "Unticked files done."
+echo "====================================================================================="
+echo "Checking for merge conflicts. . ."
 find_all_in_dir "code"
 find_all_in_dir "tgui"
-echo "Conflict checking done. Updating DME."
+echo "Conflict checking done."
+echo "====================================================================================="
+echo "Updating DME. . ."
 update_dme tgstation.dme jollystation.dme
-echo "DME update down. Updating build.js"
+echo "DME update done."
+echo "====================================================================================="
+echo "Updating build.js. . ."
 update_build
 echo "All tasks done."

--- a/jollystation_modules/README.md
+++ b/jollystation_modules/README.md
@@ -78,12 +78,20 @@ This module system edits the launch.json and the build.bat files so VSCODE can c
 
 # Upstream merge:
 
-The time has come for doom. Pull from upstream and pray. Things will probably be broken. Try to fix as many as possible. Merge conflicts will be likely. Try to solve them sensibly. When all's done, you need to update our jollystation.dme with the changes done to tgstation.dme by hand.
+The time has come for doom. Pull from upstream and pray.
 
-- Either manually copy-paste the new tgstation.dme over into jollystation.dme up to our files and you're done.
-- ...Or run _merge_update_dme.bash in gitbash, with the arguments of `<tgstation.dme>` and `<jollystation.dme>`.
+- Run ./_merge_driver.bash from gitbash (or any bash terminal, I guess) This will do a few things:
+	- A list of all unticked files in the code directory will be printed.
+		- Either delete the unticked files, or leave them if you desire.
+	- All files with merge conflict markers will be parsed through.
+		- All JSON files with merge conflicts will need to be resolved manually.
+		- All JS and DM files that don't have a modular comment will have its merge conflicts automatically resolved.
+		- All JS and DM files with a modular comment will need to be resolved manually.
+	- jollystation.dme will be updated to tgstation.dme automatically.
+	- build.js, if it was changed, will attempt to update automatically. Merge conflicts may persist in the file.
+- After the merge driver is ran, minor maintenance and resolving merge conflicts will be expected. Then, it's done.
 
-Everything should be set to try to compile. If there are errors, try to solve them. If it compiles and the game itself seems wonky, then probably call your local coder and cry.
+Everything should be set to try to compile. If there are errors, try to solve them. If it compiles and the game itself seems wonky, then call your local coder and cry.
 
 - Make sure that (to maintainers and Jolly) the commit message is not the garbled mess that it is. Change it. Please.
 


### PR DESCRIPTION
Back at it again with the shitty bash scripting to make upstream merges easier. Eventually I will rewrite this in python or something, but everyone has bash so

- The merge driver will now detect if there are unticked files in the tgstation.dme. It currently does not delete the files, just print out which files are unticked.
![image](https://user-images.githubusercontent.com/51863163/128484958-463b42bb-9cb7-4d2c-be4c-fd95ffc7315f.png)
- The merge driver now has a progress bar (sort of). Every 3 files it parses, it will print a dot. Currently, it can't really be used to tell how long you have to wait for it to complete, BUT it shows you that progress is being made, instead of it stalling on a file for some reason