### PR TITLE
Luciferium must be ingested, is (relatively) less addictive

### DIFF
--- a/jollystation_modules/code/modules/reagents/chemistry/reagents/rim_reagents.dm
+++ b/jollystation_modules/code/modules/reagents/chemistry/reagents/rim_reagents.dm
@@ -46,13 +46,11 @@
 
 /datum/reagent/medicine/luciferium/on_mob_end_metabolize(mob/living/carbon/user)
 	. = ..()
-	user.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/luciferium)
-	REMOVE_TRAIT(user, TRAIT_ANTICONVULSANT, type)
-	REMOVE_TRAIT(user, TRAIT_DISEASE_RESISTANT, type)
-	REMOVE_TRAIT(user, TRAIT_NOSOFTCRIT, type)
-	REMOVE_TRAIT(user, TRAIT_NOCRITDAMAGE, type)
-	REMOVE_TRAIT(user, TRAIT_NIGHT_VISION, type)
-	REMOVE_TRAIT(user, TRAIT_COAGULATING, type)
+	stop_effects(user)
+
+/datum/reagent/medicine/luciferium/overdose_start(mob/living/user)
+	. = ..()
+	stop_effects(user)
 
 /datum/reagent/medicine/luciferium/expose_mob(mob/living/exposed_mob, methods, reac_volume, show_message, touch_protection)
 	. = ..()
@@ -122,7 +120,10 @@
 	if(bloodiest_wound)
 		bloodiest_wound.blood_flow = max(0, bloodiest_wound.blood_flow - (0.5 * REM * delta_time))
 
-/datum/reagent/medicine/luciferium/overdose_start(mob/living/user)
+/*
+ * Stop the effects of the chem.
+ */
+/datum/reagent/medicine/luciferium/proc/stop_effects(mob/living/user)
 	user.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/luciferium)
 	REMOVE_TRAIT(user, TRAIT_ANTICONVULSANT, type)
 	REMOVE_TRAIT(user, TRAIT_DISEASE_RESISTANT, type)
@@ -130,8 +131,6 @@
 	REMOVE_TRAIT(user, TRAIT_NOCRITDAMAGE, type)
 	REMOVE_TRAIT(user, TRAIT_NIGHT_VISION, type)
 	REMOVE_TRAIT(user, TRAIT_COAGULATING, type)
-	. = ..()
-	return TRUE
 
 /obj/item/reagent_containers/pill/luciferium
 	name = "luciferium pill"
@@ -200,10 +199,11 @@
 
 /datum/reagent/drug/gojuice/on_mob_end_metabolize(mob/living/user)
 	. = ..()
-	user.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/gojuice)
-	SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, type)
-	REMOVE_TRAIT(user, TRAIT_NIGHT_VISION, type)
-	REMOVE_TRAIT(user, TRAIT_NOSOFTCRIT, type)
+	stop_effects(user)
+
+/datum/reagent/drug/gojuice/overdose_start(mob/living/user)
+	. = ..()
+	stop_effects(user)
 
 /datum/reagent/drug/gojuice/on_mob_life(mob/living/carbon/user, delta_time, times_fired)
 	if(overdosed)
@@ -216,13 +216,6 @@
 	. = ..()
 	return TRUE
 
-/datum/reagent/drug/gojuice/overdose_start(mob/living/user)
-	. = ..()
-	user.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/gojuice)
-	SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, type)
-	REMOVE_TRAIT(user, TRAIT_NIGHT_VISION, type)
-	REMOVE_TRAIT(user, TRAIT_NOSOFTCRIT, type)
-
 /datum/reagent/drug/gojuice/overdose_process(mob/living/user, delta_time, times_fired)
 	if(DT_PROB(66, delta_time))
 		user.adjustOrganLoss(ORGAN_SLOT_BRAIN, rand(1, 3) * REM * delta_time)
@@ -230,6 +223,15 @@
 		user.adjustToxLoss(1 * REM * delta_time, FALSE)
 	. = ..()
 	return TRUE
+
+/*
+ * Remove the effects of the drug.
+ */
+/datum/reagent/drug/gojuice/proc/stop_effects(mob/living/user)
+	user.remove_movespeed_modifier(/datum/movespeed_modifier/reagent/gojuice)
+	SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, type)
+	REMOVE_TRAIT(user, TRAIT_NIGHT_VISION, type)
+	REMOVE_TRAIT(user, TRAIT_NOSOFTCRIT, type)
 
 /datum/chemical_reaction/gojuice
 	results = list(/datum/reagent/drug/gojuice = 3)

--- a/jollystation_modules/code/modules/reagents/chemistry/reagents/rim_reagents.dm
+++ b/jollystation_modules/code/modules/reagents/chemistry/reagents/rim_reagents.dm
@@ -21,7 +21,7 @@
 		Drastically improves the user's bodily functions but will cause eventual death if mechanite cohesion is not sustained with continuous dosage. \
 		Once used, the pressence and effects of the mechanites are irreversible, leading to the nickname \'Devil's Bargain\' by many."
 	taste_description = "dread"
-	reagent_state = LIQUID
+	reagent_state = SOLID
 	color = "#a80008"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 12
@@ -56,8 +56,10 @@
 
 /datum/reagent/medicine/luciferium/expose_mob(mob/living/exposed_mob, methods, reac_volume, show_message, touch_protection)
 	. = ..()
-	if(!(methods & INGEST)) // If we're not ingested, delete ourselves.
-		exposed_mob.reagents.del_reagent(type)
+	if(!(methods & (PATCH|INGEST))) // If we're not ingested, delete ourselves.
+		exposed_mob.reagents.remove_reagent(type, reac_volume)
+	if(methods & INJECT)
+		exposed_mob.visible_message(span_warning("The [name] nanomachine web disintegrates upon injection into [exposed_mob]!"))
 
 /datum/reagent/medicine/luciferium/on_mob_life(mob/living/carbon/user, delta_time, times_fired)
 	if(overdosed)
@@ -244,7 +246,7 @@
 /datum/reagent/drug/flake
 	name = "Flake"
 	description = "A hard drug made from the distant psychoid leaf. While easy to produce and potent, it is also incredibly addictive."
-	reagent_state = LIQUID
+	reagent_state = SOLID
 	color = "#c9ffbc"
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
@@ -271,7 +273,7 @@
 	description = "A hard drug made from the distant psychoid leaf. Moderatively addictive and causes mild liver damage, but effective at \
 		supressing pain, reducing tiredness, and improving the user's mood."
 	taste_description = "chalk"
-	reagent_state = LIQUID
+	reagent_state = SOLID
 	color = "#e2e2e2"
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED

--- a/jollystation_modules/code/modules/reagents/chemistry/reagents/rim_reagents.dm
+++ b/jollystation_modules/code/modules/reagents/chemistry/reagents/rim_reagents.dm
@@ -27,7 +27,7 @@
 	overdose_threshold = 12
 	ph = 12.4
 	chemical_flags = REAGENT_CAN_BE_SYNTHESIZED
-	addiction_types = list(/datum/addiction/luciferium = 100) // 1 unit = addiction
+	addiction_types = list(/datum/addiction/luciferium = 33) // 3 units = addiction
 	pain_modifier = 0.8
 
 /datum/reagent/medicine/luciferium/on_mob_metabolize(mob/living/carbon/user)
@@ -53,6 +53,11 @@
 	REMOVE_TRAIT(user, TRAIT_NOCRITDAMAGE, type)
 	REMOVE_TRAIT(user, TRAIT_NIGHT_VISION, type)
 	REMOVE_TRAIT(user, TRAIT_COAGULATING, type)
+
+/datum/reagent/medicine/luciferium/expose_mob(mob/living/exposed_mob, methods, reac_volume, show_message, touch_protection)
+	. = ..()
+	if(!(methods & INGEST)) // If we're not ingested, delete ourselves.
+		exposed_mob.reagents.del_reagent(type)
 
 /datum/reagent/medicine/luciferium/on_mob_life(mob/living/carbon/user, delta_time, times_fired)
 	if(overdosed)


### PR DESCRIPTION
- Luciferium needs to be applied via ingestion, gel, or patch to gain its effects.
- Luciferium is 3x less addictive.
- Cleaned up some of the code for consistency.
- Made some of the rim-chems `solid` instead of `liquid`.