### PR TITLE
critical lima fix

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -2809,9 +2809,8 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "bsT" = (
-/obj/structure/table/optable{
-	desc = "A cold, hard place for your final rest.";
-	name = "Morgue Slab"
+/obj/machinery/computer/operating{
+	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
@@ -3124,8 +3123,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
 "bAt" = (
-/obj/machinery/computer/operating{
-	dir = 8
+/obj/structure/table/optable{
+	desc = "A cold, hard place for your final rest.";
+	name = "Morgue Slab"
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
@@ -20958,13 +20958,7 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "jDo" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
+/obj/machinery/oven,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "jDx" = (
@@ -25785,6 +25779,7 @@
 /area/maintenance/central/secondary)
 "lxc" = (
 /obj/structure/table,
+/obj/item/book/manual/wiki/cooking_to_serve_man,
 /obj/item/kitchen/rollingpin,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
@@ -26880,6 +26875,12 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"lSP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/iron/cafeteria,
+/area/service/kitchen)
 "lSY" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -40624,7 +40625,6 @@
 /area/science/xenobiology)
 "rpW" = (
 /obj/structure/table,
-/obj/item/book/manual/wiki/cooking_to_serve_man,
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
@@ -41957,7 +41957,7 @@
 /area/security/brig)
 "rSU" = (
 /obj/machinery/bounty_board/directional/north,
-/obj/effect/landmark/bridge_officer_equipment/spawn_anchored,
+/obj/effect/landmark/locker_spawner/bridge_officer_equipment,
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/iron/dark/textured,
 /area/security/detectives_office/bridge_officer_office)
@@ -86376,7 +86376,7 @@ kQi
 vdx
 fkC
 lrP
-lrP
+lSP
 jDo
 flA
 jep


### PR DESCRIPTION
why:
microwave no make 🍞
oven make 🍞

what i do:
microwave (no 🍞) -> oven (yes 🍞)

Also fixes the BO locker I guess.