### PR TITLE
Advanced Changelings, Neutered Changelings, and other refactoring

### DIFF
--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -83,12 +83,12 @@
 	emporium_action.Grant(owner.current)
 
 /datum/antagonist/changeling/on_gain()
-	create_actions()
-	reset_powers()
-	create_initial_profile()
+
+	/// NON-MODULE CHANGE: ADVANCED CHANGELINGS
 	if(give_objectives)
+		finalize_antag()
 		forge_objectives()
-	owner.current.grant_all_languages(FALSE, FALSE, TRUE) //Grants omnitongue. We are able to transform our body after all.
+
 	. = ..()
 
 /datum/antagonist/changeling/on_removal()

--- a/jollystation.dme
+++ b/jollystation.dme
@@ -3844,6 +3844,8 @@
 #include "jollystation_modules\code\modules\antagonists\_common\antag_datum.dm"
 #include "jollystation_modules\code\modules\antagonists\advanced_heretic\advanced_heretic.dm"
 #include "jollystation_modules\code\modules\antagonists\advanced_heretic\eldritch_knowledge.dm"
+#include "jollystation_modules\code\modules\antagonists\advanced_ling\advanced_ling.dm"
+#include "jollystation_modules\code\modules\antagonists\advanced_ling\neutered_ling.dm"
 #include "jollystation_modules\code\modules\antagonists\advanced_traitor\advanced_malf.dm"
 #include "jollystation_modules\code\modules\antagonists\advanced_traitor\advanced_traitor.dm"
 #include "jollystation_modules\code\modules\antagonists\infiltrator\advanced_infiltrator.dm"

--- a/jollystation_modules/code/__DEFINES/antag_defines.dm
+++ b/jollystation_modules/code/__DEFINES/antag_defines.dm
@@ -3,36 +3,51 @@
 #define CAN_SEE_EXPOITABLE_INFO (1<<0)
 
 /// Initial / base TC for advanced traitors.
-#define TRAITOR_PLUS_INITIAL_TC 8
+#define ADV_TRAITOR_INITIAL_TC 8
 /// Max amount of TC advanced traitors can get.
-#define TRAITOR_PLUS_MAX_TC 40
+#define ADV_TRAITOR_MAX_TC 40
+/// Amount of TC gained per intensity level
+#define ADV_TRAITOR_TC_PER_INTENSITY 2
 
 /// Initial / base processing points for malf AI advanced traitors.
-#define TRAITOR_PLUS_INITIAL_MALF_POINTS 20
+#define ADV_TRAITOR_INITIAL_MALF_POINTS 20
 /// Max amount of processing points for malf AI advanced traitors.
-#define TRAITOR_PLUS_MAX_MALF_POINTS 60
+#define ADV_TRAITOR_MAX_MALF_POINTS 60
+/// Amount of rocessing points gained per intensity level
+#define ADV_TRAITOR_MALF_POINTS_PER_INTENSITY 5
 
 /// Initial / base charges a heretic gets.
-#define HERETIC_PLUS_INITIAL_INFLUENCE 0
+#define ADV_HERETIC_INITIAL_INFLUENCE 0
 /// Max amount of influence charges for heretic advanced traitors.
-#define HERETIC_PLUS_MAX_INFLUENCE 5
+#define ADV_HERETIC_MAX_INFLUENCE 5
 /// This number is added onto the max influences if ascencion is given up.
-#define HERETIC_PLUS_NO_ASCENSION_MAX 3
+#define ADV_HERETIC_NO_ASCENSION_MAX 3
 /// This number is added onto the max influences if sacrificing is given up.
-#define HERETIC_PLUS_NO_SAC_MAX 3
+#define ADV_HERETIC_NO_SAC_MAX 3
+/// Number of influences gained per intensity level
+#define ADV_HERETIC_INFLUENCE_PER_INTENSITY 0.33
+
+/// The initial number of points for changelings
+#define ADV_CHANGELING_INITIAL_POINTS 4
+/// The max number of points for changelings
+#define ADV_CHANGELING_MAX_POINTS 12
+/// How many points a changeling gets per intensity level
+#define ADV_CHANGELING_POINTS_PER_INTENSITY 0.5
+/// How much chem storage a changeling gets per genetic point
+#define ADV_CHANGELING_CHEM_PER_POINTS 7.5
 
 /// Max amount of goals an advanced traitor can add.
-#define TRAITOR_PLUS_MAX_GOALS 5
+#define ADV_TRAITOR_MAX_GOALS 5
 /// Max amount of similar objectives an advanced traitor can add.
-#define TRAITOR_PLUS_MAX_SIMILAR_OBJECTIVES 5
+#define ADV_TRAITOR_MAX_SIMILAR_OBJECTIVES 5
 
 /// Max char length of goals.
-#define TRAITOR_PLUS_MAX_GOAL_LENGTH 250
+#define ADV_TRAITOR_MAX_GOAL_LENGTH 250
 /// Max char length of notes.
-#define TRAITOR_PLUS_MAX_NOTE_LENGTH 175
+#define ADV_TRAITOR_MAX_NOTE_LENGTH 175
 
 /// Intensity levels for advanced antags.
-#define TRAITOR_PLUS_INTENSITIES list( \
+#define ADV_TRAITOR_INTENSITIES list( \
 	"5 = Mass killings, destroying entire departments", \
 	"4 = Mass sabotage (engine delamination)", \
 	"3 = Assassination / Grand Theft", \

--- a/jollystation_modules/code/modules/antagonists/_common/advanced_antag.dm
+++ b/jollystation_modules/code/modules/antagonists/_common/advanced_antag.dm
@@ -9,8 +9,6 @@
 	var/employer = "The Badmins"
 	/// This player's backstory for their antag - optional, can be empty/null
 	var/backstory = ""
-	/// The style of this antag's UI.
-	var/style = "neutral"
 	/// The starting "traitor fun points" for our antag. TC, processing power, etc.
 	var/starting_points = 0
 	/// Lazylist of our goals datums linked to this antag.

--- a/jollystation_modules/code/modules/antagonists/_common/advanced_antag.dm
+++ b/jollystation_modules/code/modules/antagonists/_common/advanced_antag.dm
@@ -19,6 +19,7 @@
 	var/static/list/possible_objectives = list()
 	/// Whether our goals are finalized.
 	var/finalized = FALSE
+	/// The type of advanced panel datum we make / open
 	var/advanced_panel_type = /datum/advanced_antag_panel
 	/// All advanced traitor panels we have open (assoc list user to panel)
 	var/list/open_panels
@@ -93,15 +94,7 @@
 
 	tgui = new advanced_panel_type(user, src)
 	tgui.ui_interact(user)
-	LAZYADDASSOC(open_panels, user, tgui)
-
-/// This proc cleans up the open_panels list after a panel viewer closes the UI.
-/// viewer - the mob that just closed the panel.
-/datum/advanced_antag_datum/proc/cleanup_advanced_traitor_panel(mob/viewer)
-	open_panels -= viewer
-
-	if(!LAZYLEN(open_panels))
-		LAZYNULL(open_panels)
+	LAZYSET(open_panels, user, tgui)
 
 /// Modify the traitor's starting_points (TC, processing points, etc) based on their goals's intensity levels.
 /datum/advanced_antag_datum/proc/modify_antag_points()
@@ -123,12 +116,17 @@
 		return FALSE
 
 	finalized = TRUE
+	linked_antagonist.finalize_antag()
+	modify_antag_points()
+	log_goals_on_finalize()
+
 	return TRUE
 
 /// Miscellaneous logging for the antagonist's goals after they finalize them.
 /// Extend this proc for adding in extra logging to an antagonist.
 /datum/advanced_antag_datum/proc/log_goals_on_finalize()
 	SHOULD_CALL_PARENT(TRUE)
+
 	var/mob/antag = linked_antagonist.owner.current
 	message_admins("[ADMIN_LOOKUPFLW(antag)] finalized their objectives. They began with [starting_points] antagonist points as a [linked_antagonist.name]. ")
 	log_game("[key_name(antag)] finalized their objectives. Their began with [starting_points] antagonist points as a [linked_antagonist.name]. ")

--- a/jollystation_modules/code/modules/antagonists/_common/advanced_objective.dm
+++ b/jollystation_modules/code/modules/antagonists/_common/advanced_objective.dm
@@ -33,11 +33,11 @@
 
 /// Set our goal to our passed goal.
 /datum/advanced_antag_goal/proc/set_goal_text(goal)
-	src.goal = strip_html_simple(goal, TRAITOR_PLUS_MAX_GOAL_LENGTH)
+	src.goal = strip_html_simple(goal, ADV_TRAITOR_MAX_GOAL_LENGTH)
 
 /// Set our goal to our passed goal.
 /datum/advanced_antag_goal/proc/set_note_text(notes)
-	src.notes = strip_html_simple(notes, TRAITOR_PLUS_MAX_NOTE_LENGTH)
+	src.notes = strip_html_simple(notes, ADV_TRAITOR_MAX_NOTE_LENGTH)
 
 /// Set our intensity level to our passed intensity.
 /datum/advanced_antag_goal/proc/set_intensity(intensity)

--- a/jollystation_modules/code/modules/antagonists/_common/advanced_traitor_panel.dm
+++ b/jollystation_modules/code/modules/antagonists/_common/advanced_traitor_panel.dm
@@ -42,7 +42,7 @@
 
 /datum/advanced_antag_panel/ui_close()
 	open_ui = null
-	owner_datum.cleanup_advanced_traitor_panel(viewer)
+	LAZYREMOVE(owner_datum.open_panels, viewer)
 	qdel(src)
 
 /datum/advanced_antag_panel/ui_interact(mob/user, datum/tgui/ui)
@@ -150,7 +150,7 @@
 
 		/// Goal Stuff
 		if("add_advanced_goal")
-			if(LAZYLEN(owner_datum.our_goals) >= TRAITOR_PLUS_MAX_GOALS)
+			if(LAZYLEN(owner_datum.our_goals) >= ADV_TRAITOR_MAX_GOALS)
 				to_chat(usr, "Maximum amount of goals reached.")
 				return
 
@@ -174,7 +174,7 @@
 			. = TRUE
 
 		if("add_similar_objective")
-			if(LAZYLEN(edited_goal.similar_objectives) >= TRAITOR_PLUS_MAX_SIMILAR_OBJECTIVES)
+			if(LAZYLEN(edited_goal.similar_objectives) >= ADV_TRAITOR_MAX_SIMILAR_OBJECTIVES)
 				to_chat(usr, "Maximum amount of similar objectives reached for this goal.")
 				return
 
@@ -332,6 +332,29 @@ If you don't set any similar objectives, success won't even be checked at the en
 				return
 			our_heretic.sacrifices_enabled = !our_heretic.sacrifices_enabled
 			. = TRUE
+
+/datum/advanced_antag_panel/changeling
+	ui_to_open = "_AdvancedChangelingPanel"
+
+/datum/advanced_antag_panel/changeling/ui_data(mob/user)
+	. = ..()
+	var/datum/advanced_antag_datum/changeling/our_ling = owner_datum
+	.["cannot_absorb"] = our_ling.no_hard_absorb
+
+/datum/advanced_antag_panel/changeling/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	/// Ling Stuff
+	switch(action)
+		if("toggle_absorb")
+			var/datum/advanced_antag_datum/changeling/our_ling = owner_datum
+			if(our_ling.finalized)
+				return
+			our_ling.no_hard_absorb = !our_ling.no_hard_absorb
+			. = TRUE
+
 
 #undef TUTORIAL_OFF
 

--- a/jollystation_modules/code/modules/antagonists/_common/antag_datum.dm
+++ b/jollystation_modules/code/modules/antagonists/_common/antag_datum.dm
@@ -8,9 +8,12 @@
 	/// The advanced antag datum we are linked to.
 	var/datum/advanced_antag_datum/linked_advanced_datum
 	/// Some blacklisted objectives we don't want showing up in the similar objectives pool
-	var/static/list/blacklisted_similar_objectives = list("custom", "absorb", "nuclear", "capture")
-	/// Goals that advanced traitor malf AIs shouldn't be able to pick
-	var/static/list/blacklisted_ai_objectives = list("survive", "destroy AI", "download", "steal", "escape", "debrain")
+	var/static/list/blacklisted_similar_objectives = list(
+		"custom",
+		"absorb",
+		"nuclear",
+		"capture",
+		)
 
 /// Antagonist-level proc to show this antagonist their advanced antag panel, should they have the datum.
 /datum/antagonist/proc/show_advanced_traitor_panel(mob/user)
@@ -18,6 +21,16 @@
 		return
 
 	linked_advanced_datum.show_advanced_antag_panel(user)
+
+/datum/antagonist/get_admin_commands()
+	. = ..()
+	if(linked_advanced_datum)
+		.["View Goals"] = CALLBACK(src, .proc/show_advanced_traitor_panel, usr)
+
+/datum/antagonist/antag_listing_commands()
+	. = ..()
+	if(linked_advanced_datum)
+		. += "<a href='?_src_=holder;[HrefToken()];admin_check_goals=[REF(src)]'>Show Goals</a>"
 
 /// An extension of the admin topic for the extra buttons.
 /datum/admins/Topic(href, href_list)

--- a/jollystation_modules/code/modules/antagonists/advanced_heretic/advanced_heretic.dm
+++ b/jollystation_modules/code/modules/antagonists/advanced_heretic/advanced_heretic.dm
@@ -6,15 +6,21 @@
 	give_equipment = FALSE
 	finalize_antag = FALSE
 	/// Static list of extra objectives heretics have.
-	var/static/list/heretic_objectives = list("sacrifice" = /datum/objective/sacrifice_ecult/adv)
+	var/static/list/heretic_objectives = list(
+		"sacrifice" = /datum/objective/sacrifice_ecult/adv,
+		"exile" = /datum/objective/exile,
+		)
 
 /datum/antagonist/heretic/advanced/on_gain()
-	name = "Heretic"
 
 	if(!GLOB.admin_objective_list)
 		generate_admin_objective_list()
 
-	var/list/objectives_to_choose = GLOB.admin_objective_list.Copy() - blacklisted_similar_objectives + heretic_objectives
+	var/list/objectives_to_choose = GLOB.admin_objective_list.Copy()
+	objectives_to_choose -= blacklisted_similar_objectives
+	objectives_to_choose += heretic_objectives
+	name = "Heretic"
+
 	linked_advanced_datum = new /datum/advanced_antag_datum/heretic(src)
 	linked_advanced_datum.setup_advanced_antag()
 	linked_advanced_datum.possible_objectives = objectives_to_choose
@@ -28,6 +34,9 @@
 	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ecult_op.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
 	to_chat(owner, span_boldannounce("You are the Heretic!"))
 
+/datum/antagonist/heretic/advanced/finalize_antag()
+	equip_cultist()
+
 /datum/antagonist/heretic/advanced/forge_primary_objectives()
 	return FALSE
 
@@ -36,7 +45,7 @@
 
 	var/datum/advanced_antag_datum/heretic/our_heretic = linked_advanced_datum
 	parts += printplayer(owner)
-	parts += "<b>[owner]</b> was \a <b>[our_heretic.name]</b>[our_heretic.employer? ", a follower of <b>[our_heretic.employer]</b>":""]."
+	parts += "<b>[owner]</b> was a/an <b>[our_heretic.name]</b>[our_heretic.employer? ", a follower of <b>[our_heretic.employer]</b>":""]."
 	if(our_heretic.sacrifices_enabled)
 		parts += span_bold("Sacrifices Made: [total_sacrifices]")
 	else
@@ -45,16 +54,14 @@
 	if(LAZYLEN(linked_advanced_datum.our_goals))
 		var/count = 1
 		for(var/datum/advanced_antag_goal/goal as anything in linked_advanced_datum.our_goals)
-			parts += goal.get_roundend_text(count)
-			count++
+			parts += goal.get_roundend_text(count++)
 		if(our_heretic.ascension_enabled)
 			if(ascended)
 				parts += span_big(span_greentext("THE HERETIC ASCENDED!"))
 		else
 			parts += span_bold("<br>The heretic gave up the rite of ascension!")
 
-	if(give_equipment)
-
+	if(linked_advanced_datum.finalized)
 		parts += "<br>The heretic was bestowed [our_heretic.starting_points] influences in their initial Codex."
 		parts += span_bold("Knowledge Researched: ")
 
@@ -71,16 +78,6 @@
 
 /datum/antagonist/heretic/advanced/roundend_report_footer()
 	return "<br>And thus closes another book on board [station_name()]."
-
-/// An extra button for the TP, to open the goal panel
-/datum/antagonist/heretic/advanced/get_admin_commands()
-	. = ..()
-	.["View Goals"] = CALLBACK(src, .proc/show_advanced_traitor_panel, usr)
-
-/// An extra button for check_antagonists, to open the goal panel
-/datum/antagonist/heretic/advanced/antag_listing_commands()
-	. = ..()
-	. += "<a href='?_src_=holder;[HrefToken()];admin_check_goals=[REF(src)]'>Show Goals</a>"
 
 /// The advanced antag datum for heretics.
 /datum/advanced_antag_datum/heretic
@@ -118,17 +115,17 @@
 /// Roughly 1 influence per 3 intensity levels.
 /// Flat +3 from disabling ascension, and another +3 from disabling sacrifices.
 /datum/advanced_antag_datum/heretic/get_antag_points_from_goals()
-	var/finalized_influences = HERETIC_PLUS_INITIAL_INFLUENCE
-	var/max_influnces = HERETIC_PLUS_MAX_INFLUENCE
+	var/finalized_influences = ADV_HERETIC_INITIAL_INFLUENCE
+	var/max_influnces = ADV_HERETIC_MAX_INFLUENCE
 	if(!ascension_enabled)
 		finalized_influences += 3
-		max_influnces += HERETIC_PLUS_NO_ASCENSION_MAX
+		max_influnces += ADV_HERETIC_NO_ASCENSION_MAX
 	if(!sacrifices_enabled)
 		finalized_influences += 3
-		max_influnces += HERETIC_PLUS_NO_SAC_MAX
+		max_influnces += ADV_HERETIC_NO_SAC_MAX
 
 	for(var/datum/advanced_antag_goal/goal as anything in our_goals)
-		finalized_influences += (goal.intensity / 3)
+		finalized_influences += (goal.intensity * ADV_HERETIC_INFLUENCE_PER_INTENSITY)
 
 	return min(round(finalized_influences), max_influnces)
 
@@ -142,11 +139,6 @@ You can still edit your goals after finalizing, but you will not be able to re-e
 	. = ..()
 	if(!.)
 		return
-
-	our_heretic.give_equipment = TRUE
-	our_heretic.equip_cultist()
-	modify_antag_points()
-	log_goals_on_finalize()
 
 	if(!ascension_enabled)
 		if(our_heretic.gain_knowledge(/datum/eldritch_knowledge/no_ascension))

--- a/jollystation_modules/code/modules/antagonists/advanced_ling/advanced_ling.dm
+++ b/jollystation_modules/code/modules/antagonists/advanced_ling/advanced_ling.dm
@@ -64,20 +64,21 @@
 			result += "<br>They were given <b>[linked_advanced_datum.starting_points]</b> genetic points to accomplish these tasks."
 
 	if(our_ling.no_hard_absorb)
-		result += "<br>The changeling gave up the ability to absorb humans!"
+		result += "The changeling gave up the ability to absorb humans!"
 
-	if(linked_advanced_datum.finalized)
+	var/list/powers = purchasedpowers
+	if(powers.len && linked_advanced_datum.finalized)
 		var/list/bought_powers = list()
-		for(var/datum/action/changeling/power as anything in purchasedpowers)
+		for(var/datum/action/changeling/power as anything in powers)
 			if(power.dna_cost > 0)
 				bought_powers += power.name
 
 		if(bought_powers.len)
-			result += span_bold("<br>The changeling aquired the following powers: [english_list(bought_powers)].")
+			result += span_bold("The changeling aquired the following powers: [english_list(bought_powers)].")
 		else
-			result += span_bold("<br>The [name] never aquired any changeling powers!")
+			result += span_bold("The [name] never aquired any additional changeling powers!")
 	else
-		result += span_bold("<br>The [name] never recieved their changeling powers! ...Why?")
+		result += span_bold("The [name] never recieved their changeling powers! ...Why?")
 
 	return result.Join("<br>")
 

--- a/jollystation_modules/code/modules/antagonists/advanced_ling/advanced_ling.dm
+++ b/jollystation_modules/code/modules/antagonists/advanced_ling/advanced_ling.dm
@@ -1,0 +1,144 @@
+/// -- Advanced changelings. --
+
+/datum/antagonist/changeling/finalize_antag()
+	create_actions()
+	reset_powers()
+	create_initial_profile()
+	owner.current.grant_all_languages(FALSE, FALSE, TRUE) //Grants omnitongue. We are able to transform our body after all.
+
+/// The Advanecd Traitor antagonist datum.
+/datum/antagonist/changeling/advanced
+	name = "Advanced Changeling"
+	ui_name = null
+	hijack_speed = 0.5
+	give_objectives = FALSE
+	you_are_greet = FALSE
+	/// List of objectives changelings can get in addition to the base ones
+	var/static/list/ling_objectives = list(
+		"absorb" = /datum/objective/absorb,
+		"absorb most" = /datum/objective/absorb_most,
+		"absorb changeling" = /datum/objective/absorb_changeling,
+		"escape with identity" = /datum/objective/escape/escape_with_identity,
+		"exile" = /datum/objective/exile,
+		)
+
+/datum/antagonist/changeling/advanced/create_initial_profile()
+	add_new_profile(owner.current, TRUE)
+
+/datum/antagonist/changeling/advanced/on_gain()
+	if(!GLOB.admin_objective_list)
+		generate_admin_objective_list()
+
+	var/list/objectives_to_choose = GLOB.admin_objective_list.Copy()
+	objectives_to_choose -= blacklisted_similar_objectives
+	objectives_to_choose += ling_objectives
+	name = "Changeling"
+
+	linked_advanced_datum = new /datum/advanced_antag_datum/changeling(src)
+	linked_advanced_datum.setup_advanced_antag()
+	linked_advanced_datum.possible_objectives = objectives_to_choose
+	return ..()
+
+/// Greet the antag with big menacing text.
+/datum/antagonist/changeling/advanced/greet()
+	linked_advanced_datum.greet_message(owner.current)
+
+/datum/antagonist/changeling/advanced/finalize_antag()
+	. = ..()
+	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ling_aler.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
+
+/datum/antagonist/changeling/advanced/roundend_report()
+	var/list/result = list()
+	var/datum/advanced_antag_datum/changeling/our_ling = linked_advanced_datum
+
+	result += printplayer(owner)
+	result += "<b>[owner]</b> was a/an <b>[our_ling.name]</b>[our_ling.employer? " employed by <b>[our_ling.employer]</b>":""]."
+	if(our_ling.backstory)
+		result += "<b>[owner]'s</b> backstory was the following: <br>[our_ling.backstory]"
+
+	if(LAZYLEN(linked_advanced_datum.our_goals))
+		var/count = 1
+		for(var/datum/advanced_antag_goal/goal as anything in linked_advanced_datum.our_goals)
+			result += goal.get_roundend_text(count++)
+		if(linked_advanced_datum.finalized)
+			result += "<br>They were given <b>[linked_advanced_datum.starting_points]</b> genetic points to accomplish these tasks."
+
+	if(our_ling.no_hard_absorb)
+		result += "<br>The changeling gave up the ability to absorb humans!"
+
+	if(linked_advanced_datum.finalized)
+		var/list/bought_powers = list()
+		for(var/datum/action/changeling/power as anything in purchasedpowers)
+			if(power.dna_cost > 0)
+				bought_powers += power.name
+
+		if(bought_powers.len)
+			result += span_bold("<br>The changeling aquired the following powers: [english_list(bought_powers)].")
+		else
+			result += span_bold("<br>The [name] never aquired any changeling powers!")
+	else
+		result += span_bold("<br>The [name] never recieved their changeling powers! ...Why?")
+
+	return result.Join("<br>")
+
+/datum/antagonist/changeling/advanced/roundend_report_footer()
+	return "<br>And thus ends another mystery on board [station_name()]."
+
+/// The advanced antag datum for traitor.
+/datum/advanced_antag_datum/changeling
+	name = "Advanced Changeling"
+	employer = ""
+	// Changelings have default 4 points, and gain 0.5 points per intensity level
+	starting_points = 4
+	advanced_panel_type = /datum/advanced_antag_panel/changeling
+	/// Our antag datum linked to our advanced antag.
+	var/datum/antagonist/changeling/our_changeling
+	/// Whether our changeling can hard absorb (husk) people.
+	var/no_hard_absorb = FALSE
+
+/datum/advanced_antag_datum/changeling/New(datum/antagonist/linked_antag)
+	. = ..()
+	our_changeling = linked_antag
+
+/datum/advanced_antag_datum/changeling/Destroy()
+	our_changeling = null
+	. = ..()
+
+/datum/advanced_antag_datum/changeling/modify_antag_points()
+	starting_points = get_antag_points_from_goals()
+	our_changeling.geneticpoints = starting_points
+	our_changeling.total_geneticspoints = starting_points
+
+	our_changeling.chem_charges = starting_points * 2
+	our_changeling.chem_storage = round((starting_points * ADV_CHANGELING_CHEM_PER_POINTS) + (10 * no_hard_absorb))
+	our_changeling.total_chem_storage = round((starting_points * ADV_CHANGELING_CHEM_PER_POINTS) + (10 * no_hard_absorb))
+
+/datum/advanced_antag_datum/changeling/get_antag_points_from_goals()
+	var/finalized_starting_points = ADV_CHANGELING_INITIAL_POINTS
+	for(var/datum/advanced_antag_goal/goal as anything in our_goals)
+		finalized_starting_points += round((goal.intensity * ADV_CHANGELING_POINTS_PER_INTENSITY) - 0.1) // round down
+
+	return min(finalized_starting_points, ADV_CHANGELING_MAX_POINTS)
+
+/datum/advanced_antag_datum/changeling/get_finalize_text()
+	var/starting_points = get_antag_points_from_goals()
+	return "Finalizing will give your your cellular emproium with [starting_points] genetic points, and [round((starting_points * ADV_CHANGELING_CHEM_PER_POINTS) + (10 * no_hard_absorb))] total chemical storage. [no_hard_absorb ? "You will not be able to absorb humans. ":""]You can still edit your goals after finalizing!"
+
+/datum/advanced_antag_datum/changeling/post_finalize_actions()
+	. = ..()
+	if(!.)
+		return
+
+	if(no_hard_absorb)
+		var/datum/action/changeling/absorb_dna/dna_power = locate() in our_changeling.purchasedpowers
+		dna_power?.Remove(linked_antagonist.owner.current)
+
+/datum/advanced_antag_datum/changeling/log_goals_on_finalize()
+	. = ..()
+	if(!no_hard_absorb)
+		message_admins("Absorbing enabled: [ADMIN_LOOKUPFLW(linked_antagonist.owner.current)] finalized their goals with the ability to absorb and husk enabled.")
+	log_game("[key_name(linked_antagonist.owner.current)] finalized their goals with absorbing [no_hard_absorb ? "disabled":"enabled"].")
+
+/datum/advanced_antag_datum/changeling/greet_message_two(mob/antagonist)
+	to_chat(antagonist, span_danger("You are a mysterious changeling sent to [station_name()]! You can set your goals to whatever you think would make an interesting story or round. You have access to your goal panel via verb in your IC tab."))
+	addtimer(CALLBACK(src, .proc/greet_message_three, antagonist), 3 SECONDS)

--- a/jollystation_modules/code/modules/antagonists/advanced_ling/neutered_ling.dm
+++ b/jollystation_modules/code/modules/antagonists/advanced_ling/neutered_ling.dm
@@ -28,7 +28,8 @@
 	add_new_profile(owner.current, TRUE)
 
 /datum/antagonist/changeling/neutered/reset_powers()
-	if(purchasedpowers)
+	var/list/powers = purchasedpowers
+	if(powers.len)
 		remove_changeling_powers()
 	for(var/path in allowed_powers)
 		var/datum/action/changeling/sting = new path()

--- a/jollystation_modules/code/modules/antagonists/advanced_ling/neutered_ling.dm
+++ b/jollystation_modules/code/modules/antagonists/advanced_ling/neutered_ling.dm
@@ -1,0 +1,41 @@
+/// Neutered changeling, basically changelings who can't do much of anything anymore.
+/datum/antagonist/changeling/neutered
+	name = "Neutered Changeling"
+	ui_name = null
+	hijack_speed = 0
+	give_objectives = FALSE
+	you_are_greet = FALSE
+	dna_max = 1
+	sting_range = 1
+	chem_recharge_rate = 0.1
+	chem_charges = 5
+	chem_storage = 25
+	total_chem_storage = 25
+	geneticpoints = 2
+	total_geneticspoints = 2 // You get one or two abilities, max
+
+	/// List of powers neutered lings are stuck with.
+	var/static/list/allowed_powers = list(
+		/datum/action/changeling/fakedeath,
+		/datum/action/changeling/regenerate
+		)
+
+/datum/antagonist/changeling/neutered/on_gain()
+	. = ..()
+	finalize_antag()
+
+/datum/antagonist/changeling/neutered/create_initial_profile()
+	add_new_profile(owner.current, TRUE)
+
+/datum/antagonist/changeling/neutered/reset_powers()
+	if(purchasedpowers)
+		remove_changeling_powers()
+	for(var/path in allowed_powers)
+		var/datum/action/changeling/sting = new path()
+		purchasedpowers += sting
+		sting.on_purchase(owner.current, TRUE)
+
+/datum/antagonist/changeling/neutered/greet()
+	to_chat(owner.current, span_boldannounce("You are a neutered changeling. Most of your powers are lost, and you are but a shell of your former self."))
+	owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/ling_aler.ogg', 100, FALSE, pressure_affected = FALSE, use_reverb = FALSE)
+	/// MELBERT TODO; Make this playsound sound sad

--- a/jollystation_modules/code/modules/antagonists/infiltrator/infiltrator.dm
+++ b/jollystation_modules/code/modules/antagonists/infiltrator/infiltrator.dm
@@ -36,7 +36,7 @@
 	var/list/result = list()
 
 	result += printplayer(owner)
-	result += "<b>[owner]</b> was \a <b>[linked_advanced_datum.name]</b>, sent to infiltrate [station_name()][employer? ", employed by <b>[employer]</b>":""]."
+	result += "<b>[owner]</b> was a/an <b>[linked_advanced_datum.name]</b>, sent to infiltrate [station_name()][employer? ", employed by <b>[employer]</b>":""]."
 	if(linked_advanced_datum.backstory)
 		result += "<b>[owner]'s</b> backstory was the following: <br>[linked_advanced_datum.backstory]"
 
@@ -44,27 +44,26 @@
 	var/uplink_true = FALSE
 	var/purchases = ""
 
-	if(give_uplink)
+	if(linked_advanced_datum.finalized)
 		LAZYINITLIST(GLOB.uplink_purchase_logs_by_key)
-		var/datum/uplink_purchase_log/H = GLOB.uplink_purchase_logs_by_key[owner.key]
-		if(H)
+		var/datum/uplink_purchase_log/log = GLOB.uplink_purchase_logs_by_key[owner.key]
+		if(log)
 			uplink_true = TRUE
-			TC_uses = H.total_spent
-			purchases += H.generate_render(FALSE)
+			TC_uses = log.total_spent
+			purchases += log.generate_render(FALSE)
 
 	if(LAZYLEN(linked_advanced_datum.our_goals))
 		var/count = 1
 		for(var/datum/advanced_antag_goal/goal as anything in linked_advanced_datum.our_goals)
-			result += goal.get_roundend_text(count)
-			count++
-		if(uplink_true)
+			result += goal.get_roundend_text(count++)
+		if(linked_advanced_datum.finalized)
 			result += "<br>They were afforded <b>[linked_advanced_datum.starting_points]</b> tc to accomplish these tasks."
 
-	if(uplink_true)
+	if(uplink_true && linked_advanced_datum.finalized)
 		var/uplink_text = span_bold("(used [TC_uses] TC)")
 		uplink_text += "[purchases]"
 		result += uplink_text
-	else if (!give_uplink)
+	else
 		result += span_bold("<br>The [name] never obtained their uplink!")
 
 	return result.Join("<br>")

--- a/tgui/packages/tgui/interfaces/_AdvancedChangelingPanel.js
+++ b/tgui/packages/tgui/interfaces/_AdvancedChangelingPanel.js
@@ -5,7 +5,7 @@ import { AdvancedTraitorPanelBackground } from './_AdvancedTraitorParts';
 import { AdvancedTraitorPanelGoals } from './_AdvancedTraitorParts';
 import { AdvancedTraitorTutorialModal } from './_AdvancedTraitorParts';
 
-export const _AdvancedTraitorPanel = (props, context) => {
+export const _AdvancedChangelingPanel = (props, context) => {
   const { act, data } = useBackend(context);
   const {
     antag_type,
@@ -14,6 +14,7 @@ export const _AdvancedTraitorPanel = (props, context) => {
     goals = [],
     backstory_tutorial_text,
     objective_tutorial_text,
+    cannot_absorb,
   } = data;
 
   return (
@@ -21,7 +22,7 @@ export const _AdvancedTraitorPanel = (props, context) => {
       title="Antagonist Goal Panel"
       width={550}
       height={650}
-      theme="jolly-syndicate">
+      theme="neutral">
       <Window.Content>
         <Section
           title={`${ antag_type } Background`}
@@ -60,6 +61,16 @@ export const _AdvancedTraitorPanel = (props, context) => {
             content="Add Goal"
             textAlign="center"
             onClick={() => act('add_advanced_goal')} />
+          <Button.Checkbox
+            width="140px"
+            height="20px"
+            content="Disable Absorb"
+            textAlign="center"
+            disabled={goals_finalized}
+            checked={cannot_absorb}
+            tooltip="If checked, the ability to use absorb will be disabled. \
+                    Disabling absorbing rewards +10 max chemical storage."
+            onClick={() => act('toggle_absorb')} />
           { goals_finalized === 0 && (
             <Button.Confirm
               width="112px"

--- a/tgui/packages/tgui/interfaces/_AdvancedHereticPanel.js
+++ b/tgui/packages/tgui/interfaces/_AdvancedHereticPanel.js
@@ -1,5 +1,5 @@
-import { useBackend, useSharedState } from '../backend';
-import { Button, Divider, Flex, Section } from '../components';
+import { useBackend } from '../backend';
+import { Button, Section } from '../components';
 import { Window } from '../layouts';
 import { AdvancedTraitorPanelBackground } from './_AdvancedTraitorParts';
 import { AdvancedTraitorPanelGoals } from './_AdvancedTraitorParts';
@@ -67,6 +67,7 @@ export const _AdvancedHereticPanel = (props, context) => {
             height="20px"
             content="Toggle Ascending"
             textAlign="center"
+            disabled={goals_finalized}
             checked={can_ascend}
             tooltip="Toggle the ability to ascend. \
                     Disabling ascending rewards 3 bonus charges."
@@ -76,6 +77,7 @@ export const _AdvancedHereticPanel = (props, context) => {
             height="20px"
             content="Toggle Sacrificing"
             textAlign="center"
+            disabled={goals_finalized}
             checked={can_sac}
             tooltip="Toggle the ability to sacrifice. \
                     Disabling sacrificing rewards 3 bonus charges."


### PR DESCRIPTION
- Changelings now have support for the advanced antag panel, and can set their own objectives.
![image](https://user-images.githubusercontent.com/51863163/131266340-64d2b071-ede4-4ac9-b638-c96c0495d854.png)
- Added another changeling antagonist datum, the Neutered Changeling, which is a very very weak version of a changeling. Much less chemicals, genetic points, can't absorb DNA, DNA sting, or transform. 
- Refactored a bit of advanced antag code.


- [ ] Add a way to make changelings to become a neutered ling if they were caught, or something like that
- [ ] Add other options for the ling panel
- [ ] Testing