### PR TITLE
[DNM-WIP] Lima Aesthetic DLC + Small Fixes

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -420,12 +420,12 @@
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
 "akj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/obj/structure/sign/departments/lawyer{
+	pixel_x = 32
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -437,9 +437,10 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "akB" = (
 /obj/structure/disposalpipe/segment,
@@ -511,9 +512,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "amz" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "amM" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -587,6 +587,15 @@
 /obj/structure/lattice,
 /turf/open/openspace/airless,
 /area/space/nearstation)
+"aop" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "aoZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -757,7 +766,12 @@
 "asW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/checkpoint/auxiliary)
 "atm" = (
 /turf/open/floor/plating,
@@ -770,6 +784,10 @@
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"atU" = (
+/obj/structure/sign/departments/xenobio,
+/turf/closed/wall/r_wall,
+/area/science/xenobiology)
 "aub" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -849,6 +867,14 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"awn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "awr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -867,11 +893,14 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "awI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/structure/sink{
 	pixel_y = 20
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -1445,6 +1474,12 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"aMF" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "aMG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1517,12 +1552,6 @@
 "aNW" = (
 /turf/closed/wall,
 /area/service/lawoffice)
-"aOa" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "aOf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/hangover,
@@ -1600,13 +1629,11 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"aQj" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
+"aQn" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "aQO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -1680,12 +1707,6 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
-"aTa" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "aTi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1693,13 +1714,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/teleporter)
-"aTk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "aTv" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/plating,
@@ -1795,9 +1809,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/vending/clothing,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "aVK" = (
 /obj/machinery/requests_console{
@@ -2041,6 +2056,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
+"bac" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "bal" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -2302,6 +2323,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/grimy,
 /area/maintenance/central/secondary)
+"bgS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "bhc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2611,13 +2638,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
-"bot" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "boG" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2688,6 +2708,12 @@
 "bpF" = (
 /turf/closed/wall/r_wall,
 /area/command/gateway)
+"bpX" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "bpZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2952,6 +2978,13 @@
 /obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron,
 /area/cargo/sorting)
+"byb" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "byh" = (
 /obj/structure/reagent_dispensers/peppertank/directional/north,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -3086,6 +3119,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"bAU" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "bBg" = (
 /obj/structure/table,
 /obj/item/hatchet,
@@ -3150,15 +3189,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/commons/dorms)
-"bCj" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "bCl" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
@@ -3202,11 +3232,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bCN" = (
-/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/brig)
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "bDg" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3429,11 +3461,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
-"bIf" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "bIu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -3643,6 +3670,11 @@
 /obj/machinery/smartfridge/organ,
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"bNl" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/command)
 "bNn" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer{
 	dir = 1
@@ -3678,6 +3710,13 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
+"bNG" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "bNM" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3720,6 +3759,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/gateway)
+"bOx" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "bOP" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
@@ -3779,12 +3824,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/fore)
-"bPt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "bPM" = (
 /obj/machinery/camera/motion{
 	c_tag = "Security - Armory External";
@@ -3833,7 +3872,6 @@
 /area/command/heads_quarters/cmo)
 "bRj" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bRT" = (
@@ -3915,6 +3953,18 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"bUb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/science/research)
 "bUg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4025,6 +4075,15 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"bXR" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "bYe" = (
 /obj/machinery/power/smes{
 	capacity = 9e+006;
@@ -4123,13 +4182,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"caw" = (
-/obj/machinery/duct,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "caG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -4174,8 +4226,13 @@
 /turf/open/floor/iron/sepia,
 /area/service/chapel)
 "cbZ" = (
-/turf/open/floor/iron/dark/smooth_large,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cca" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cardboard,
@@ -4201,6 +4258,17 @@
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
+"ccH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/security/brig)
 "ccI" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -4394,10 +4462,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"chv" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "chy" = (
 /obj/structure/chair/sofa/corner{
 	name = "plush sofa"
@@ -4503,18 +4567,19 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/misc_lab)
-"ckH" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "ckT" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"clv" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "clD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4545,14 +4610,6 @@
 /obj/structure/altar_of_gods,
 /turf/open/floor/carpet/red,
 /area/service/chapel)
-"cnf" = (
-/obj/structure/cable,
-/obj/machinery/duct,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "cnY" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -4756,6 +4813,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/break_room)
+"csM" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "csN" = (
 /obj/machinery/photocopier,
 /obj/item/radio/intercom{
@@ -4863,6 +4933,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"cuw" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "cuL" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
@@ -4951,15 +5026,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "cvR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/auxiliary)
 "cwi" = (
 /obj/machinery/door/window/southleft{
@@ -5219,12 +5291,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"czs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "czv" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
@@ -5279,10 +5345,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "cCP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -5408,17 +5470,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"cFv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/dark/smooth_corner{
-	dir = 8
-	},
-/area/security/brig)
 "cFz" = (
 /obj/machinery/ore_silo,
 /obj/effect/turf_decal/bot,
@@ -5522,15 +5573,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"cHz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "cHI" = (
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
@@ -5566,6 +5608,16 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/aft)
+"cIy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/science/research)
 "cIC" = (
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 4
@@ -5626,6 +5678,10 @@
 	pixel_y = -32
 	},
 /obj/structure/ladder,
+/obj/structure/sign/departments/mait{
+	pixel_x = 32;
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "cKF" = (
@@ -5695,12 +5751,6 @@
 /obj/structure/window,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"cMs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "cNa" = (
 /obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
@@ -5791,12 +5841,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
-"cPk" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "cPM" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -5965,6 +6009,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/fore)
+"cUx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "cUI" = (
 /obj/structure/sign/warning{
 	pixel_y = -32
@@ -6030,18 +6083,12 @@
 "cVV" = (
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
-"cWb" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "cWe" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/corner,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cWu" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -6173,21 +6220,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
-"cZv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "cZw" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
@@ -6332,12 +6364,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"dcK" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "dcN" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom";
@@ -6577,12 +6603,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"dhf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "dhh" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass{
@@ -6707,25 +6727,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/sign/departments/psychology{
+	pixel_y = 32
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
-"dja" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "djg" = (
 /obj/structure/cable,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/electrical)
+"djv" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "djz" = (
 /obj/structure/chair{
 	dir = 4
@@ -6764,6 +6780,13 @@
 /obj/machinery/bluespace_vendor/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"dkO" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "dlf" = (
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light/warm/directional/east,
@@ -7609,6 +7632,19 @@
 	},
 /turf/open/floor/engine,
 /area/engineering/main)
+"dDH" = (
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_one_access_txt = "5"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "dDU" = (
 /obj/structure/table,
 /obj/machinery/cell_charger{
@@ -7656,6 +7692,13 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
+"dFZ" = (
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "dGd" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "teleportershutters";
@@ -7763,18 +7806,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
-"dIN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "dIY" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden,
@@ -7793,15 +7824,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
-"dJv" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "dJz" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -7824,9 +7846,10 @@
 /area/security/brig)
 "dJS" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 6
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "dJV" = (
 /obj/item/kirbyplants/random,
@@ -7841,6 +7864,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_half,
 /area/security/office)
+"dKA" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "dKN" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/newscaster/directional/south,
@@ -8064,6 +8096,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"dQN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "dQQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -8218,12 +8258,6 @@
 	},
 /turf/open/floor/grass,
 /area/service/library)
-"dTS" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "dUl" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -8248,6 +8282,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"dVp" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "dVy" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -8279,14 +8320,13 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "dWX" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/security/brig)
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "dWZ" = (
 /turf/closed/wall/r_wall,
 /area/science/genetics)
@@ -8452,12 +8492,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
-"ebQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "ebR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -8727,6 +8761,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/maintenance/solars/starboard/aft)
+"ekX" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "ell" = (
 /turf/closed/wall/r_wall,
 /area/engineering/supermatter)
@@ -8901,21 +8942,19 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
-"epN" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "epS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"eqd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "eqe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9001,18 +9040,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"ery" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	name = "dorms sorting disposal pipe";
-	sortType = 26
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "erM" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -9524,6 +9551,19 @@
 	},
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
+"eCP" = (
+/obj/effect/turf_decal/trimline/yellow/filled/warning{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
+"eDa" = (
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "eDb" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /obj/structure/lattice/catwalk,
@@ -9739,11 +9779,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"eHe" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/command/storage/eva)
 "eHh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9808,12 +9843,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"eId" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "eIo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -10028,6 +10057,15 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"eMb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "eMq" = (
 /obj/structure/transit_tube/station{
 	dir = 1
@@ -10100,6 +10138,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
+"eNp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "eNt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
 	dir = 4
@@ -10122,9 +10167,10 @@
 /area/hallway/secondary/exit/departure_lounge)
 "eOa" = (
 /obj/machinery/vending/cola/sodie,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "eOi" = (
 /obj/effect/turf_decal/stripes/line{
@@ -10649,9 +10695,10 @@
 /area/cargo/miningdock)
 "fba" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 5
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "fbb" = (
 /obj/structure/disposalpipe/segment,
@@ -10692,6 +10739,9 @@
 /area/cargo/qm)
 "fcg" = (
 /obj/structure/ladder,
+/obj/structure/sign/departments/mait{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "fci" = (
@@ -11064,6 +11114,9 @@
 /obj/item/folder/white,
 /obj/item/pen/red,
 /obj/item/hand_labeler,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "fjc" = (
@@ -11212,6 +11265,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/security/brig)
+"fms" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "fmt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -11326,7 +11391,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/checkpoint/auxiliary)
 "fqo" = (
 /obj/structure/cable,
@@ -11422,6 +11487,16 @@
 	},
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
+"fsh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "fsi" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/camera{
@@ -11641,14 +11716,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "fux" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "fuQ" = (
@@ -11923,11 +11995,10 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
 "fCi" = (
 /obj/machinery/power/terminal{
@@ -12129,6 +12200,15 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/openspace,
 /area/science/xenobiology)
+"fGW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "fHp" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -12284,6 +12364,12 @@
 "fKw" = (
 /turf/closed/wall/r_wall,
 /area/command/bridge)
+"fKD" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "fKG" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/item/book/manual/wiki/surgery,
@@ -12335,10 +12421,6 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"fLD" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "fMj" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /obj/effect/spawner/lootdrop/maint_drugs,
@@ -12658,13 +12740,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"fTo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "fTy" = (
 /obj/structure/table,
 /obj/item/disk/tech_disk{
@@ -12743,6 +12818,13 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
+"fVu" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "fVL" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -13010,6 +13092,16 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"gcl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "gcs" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -13035,11 +13127,6 @@
 /obj/item/pestle,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"gdu" = (
-/obj/machinery/status_display/evac/directional/south,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "gdw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -13076,14 +13163,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"gef" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "ges" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -13133,14 +13212,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/science/genetics)
-"ggm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/cargo/office)
 "ggN" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table/reinforced,
@@ -13238,7 +13309,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/status_display/evac/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -13251,11 +13321,6 @@
 /area/maintenance/port/fore)
 "gjI" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -13387,14 +13452,16 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "glz" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
+"glA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "glB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -13430,6 +13497,19 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
+"gmq" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
+"gmF" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/cargo/office)
 "gmH" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13481,14 +13561,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"gnr" = (
-/obj/structure/bed,
-/obj/item/bedsheet/medical,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "gnv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13526,13 +13598,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"gou" = (
-/obj/effect/spawner/randomsnackvend,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "goI" = (
 /obj/machinery/light/small/red/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13616,6 +13681,10 @@
 /obj/effect/landmark/start/depsec/engineering,
 /turf/open/floor/iron,
 /area/engineering/main)
+"gqp" = (
+/obj/structure/sign/departments/engineering,
+/turf/closed/wall/r_wall,
+/area/engineering/lobby)
 "gqq" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -14001,13 +14070,6 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
-"gzF" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "gzN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14122,11 +14184,11 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "gBT" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
 "gCa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -14334,6 +14396,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "gHW" = (
@@ -14415,15 +14480,6 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
-"gJC" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "gJG" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -14540,6 +14596,14 @@
 "gLj" = (
 /turf/closed/wall,
 /area/hallway/primary/port)
+"gLt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "gLx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14560,9 +14624,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table/wood,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "gMq" = (
 /obj/machinery/door/airlock/public/glass{
@@ -14719,9 +14784,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gPM" = (
-/obj/structure/sign/warning/biohazard{
-	pixel_y = -30
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
@@ -14933,6 +14995,9 @@
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "gTB" = (
@@ -14962,6 +15027,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
+"gTL" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "gTO" = (
 /obj/machinery/computer/security/telescreen/engine{
 	dir = 8;
@@ -15065,14 +15136,14 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "gVU" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/white/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
 "gVY" = (
 /obj/machinery/button/door{
 	id = "visitation";
@@ -15152,6 +15223,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
+"gXb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "gXc" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -15187,6 +15265,13 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood,
 /area/service/bar)
+"gXp" = (
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "gXq" = (
 /obj/machinery/meter{
 	name = "External Ports Gas Meter"
@@ -15434,12 +15519,11 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hee" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "hek" = (
@@ -15460,13 +15544,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"hew" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "hez" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -15530,12 +15607,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
-"hfP" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/cargo/office)
 "hfW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -15544,12 +15615,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"hga" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "hgd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -15595,15 +15660,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark/textured_large,
 /area/command/heads_quarters/captain)
-"hht" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "hhv" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Pure Chamber";
@@ -15673,12 +15729,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
-"hiZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "hjh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -15732,18 +15782,6 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hkT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "hlh" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/flashlight/lantern{
@@ -16310,9 +16348,10 @@
 /area/engineering/gravity_generator)
 "hzd" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 9
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "hzo" = (
 /obj/effect/decal/cleanable/generic,
@@ -16332,6 +16371,18 @@
 /obj/structure/filingcabinet/employment,
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
+"hzR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/science/research)
 "hzX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16387,6 +16438,9 @@
 /area/science/server)
 "hBc" = (
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "hBh" = (
@@ -16561,16 +16615,6 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
-"hFJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "hHk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	dir = 1
@@ -17396,6 +17440,14 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
+"iaX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "iaY" = (
 /obj/machinery/photocopier,
 /obj/machinery/airalarm/directional/south,
@@ -17476,9 +17528,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "icn" = (
 /obj/machinery/light/small/red/directional/west,
@@ -17498,6 +17551,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "icF" = (
@@ -17513,6 +17567,9 @@
 /area/maintenance/central/secondary)
 "icK" = (
 /obj/structure/window/reinforced,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "icN" = (
@@ -17527,12 +17584,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
-"idh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "idj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -17542,6 +17593,10 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"idn" = (
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "idr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -17603,12 +17658,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
-"iek" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "ieo" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -17801,14 +17850,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"iiL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "iiO" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -17839,21 +17880,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"ijG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "ijJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17886,15 +17912,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"iki" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "ikr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -17952,16 +17969,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos/experiment_room)
-"imE" = (
-/obj/structure/disposalpipe/segment{
+"imJ" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "inb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17973,17 +17986,14 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ine" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/checkpoint/auxiliary)
 "ini" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18012,6 +18022,12 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/research)
 "inX" = (
@@ -18041,10 +18057,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/airless,
 /area/science/test_area)
-"ioF" = (
-/obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "ioU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18110,6 +18122,13 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/service/library)
+"ipX" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "iqp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/dark/smooth_half{
@@ -18127,6 +18146,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/central/secondary)
+"ire" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "iri" = (
 /obj/structure/tank_dispenser,
 /turf/open/floor/iron,
@@ -18227,6 +18252,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"isP" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "isS" = (
 /obj/machinery/atmospherics/pipe/multiz/violet/visible{
 	dir = 8;
@@ -18263,12 +18293,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
-"its" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "itA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18329,10 +18353,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "iuB" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "iuO" = (
@@ -18341,6 +18364,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"iuU" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "ivf" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
@@ -18411,6 +18440,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"iwR" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "ianroomlockdown";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/command/corporate_showroom)
 "iwT" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -18438,15 +18476,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"ixl" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "ixx" = (
 /obj/structure/chair{
 	dir = 4
@@ -18499,11 +18528,10 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
 "iyT" = (
 /obj/machinery/door/poddoor,
@@ -18514,15 +18542,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/fore)
-"izz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "izM" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -18566,11 +18585,27 @@
 	},
 /turf/open/floor/iron/white/textured,
 /area/medical/cryo)
+"iAr" = (
+/obj/structure/flora/grass/green,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "iAD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
+"iAO" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "iAW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/showroomfloor,
@@ -18661,11 +18696,10 @@
 	pixel_y = -22
 	},
 /obj/machinery/power/apc/auto_name/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/auxiliary)
 "iCP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -18691,6 +18725,13 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"iDn" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "iDH" = (
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Pens D Upper";
@@ -18883,6 +18924,12 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
 /area/security/courtroom)
+"iIu" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "iIz" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine Room";
@@ -18969,6 +19016,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /turf/open/floor/engine,
 /area/engineering/main)
+"iKH" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "iKW" = (
 /obj/structure/bookcase/random/reference,
 /obj/machinery/light/directional/north,
@@ -19093,7 +19146,7 @@
 	dir = 4
 	},
 /obj/structure/sign/departments/custodian{
-	pixel_y = 30
+	pixel_y = 32
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -19214,6 +19267,12 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"iQu" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "iRs" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -19277,18 +19336,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"iSm" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "iSv" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -19407,6 +19454,14 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"iVS" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "iWa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
@@ -19416,6 +19471,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
+"iWs" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "iWv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -19466,17 +19527,15 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
+"iXo" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "iXs" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/barricade/wooden,
 /turf/open/floor/iron/airless,
 /area/space/nearstation)
-"iXy" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/cargo/office)
 "iXA" = (
 /obj/item/kirbyplants/random,
 /obj/effect/landmark/start/hangover,
@@ -19662,6 +19721,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
+"jcO" = (
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "jcS" = (
 /obj/machinery/light/small/red/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -19711,6 +19777,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"jec" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/cargo/qm)
 "jem" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/cable,
@@ -19752,6 +19825,12 @@
 	dir = 8
 	},
 /area/security/brig)
+"jfn" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/cargo/office)
 "jfs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -19759,12 +19838,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
-"jfv" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "jgi" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/effect/decal/cleanable/dirt,
@@ -19880,6 +19953,14 @@
 /obj/structure/cable,
 /turf/open/floor/engine,
 /area/engineering/main)
+"jjj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "jjp" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
@@ -19907,15 +19988,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
-"jkD" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "jkF" = (
 /obj/structure/table/wood,
 /obj/effect/landmark/start/hangover,
@@ -20015,6 +20087,13 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"jns" = (
+/obj/effect/spawner/randomsnackvend,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "jny" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/white,
@@ -20140,12 +20219,12 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "jqj" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
 "jqq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -20410,9 +20489,10 @@
 /area/hallway/secondary/entry)
 "juq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "juJ" = (
 /obj/machinery/computer/mecha{
@@ -20444,9 +20524,10 @@
 /area/commons/toilet)
 "jva" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "jvn" = (
 /obj/machinery/camera{
@@ -20596,9 +20677,10 @@
 /area/hallway/secondary/entry)
 "jxm" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 5
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "jxD" = (
 /obj/effect/turf_decal/stripes/line,
@@ -20637,6 +20719,9 @@
 /area/maintenance/central/secondary)
 "jxY" = (
 /obj/structure/ladder,
+/obj/structure/sign/departments/mait{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "jxZ" = (
@@ -20758,11 +20843,9 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "jAO" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 10
-	},
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
 "jAQ" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20775,9 +20858,10 @@
 "jAX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "jBf" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -20849,6 +20933,9 @@
 "jCo" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "jCA" = (
@@ -20972,15 +21059,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"jFT" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "jGl" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -21243,9 +21321,10 @@
 "jKS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "jKU" = (
 /obj/structure/cable,
@@ -21289,14 +21368,11 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "jLB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/north,
 /obj/effect/spawner/randomsnackvend,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "jLG" = (
@@ -21304,14 +21380,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "jLL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/light/directional/north,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "jLY" = (
@@ -21421,16 +21494,6 @@
 /obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"jPh" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "jPr" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -21820,6 +21883,12 @@
 "jXB" = (
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
+"jXY" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "jYb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21869,6 +21938,9 @@
 "jYL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "jYN" = (
@@ -21896,9 +21968,10 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
 "jZg" = (
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "jZr" = (
 /obj/machinery/airalarm{
@@ -21984,6 +22057,11 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"kaE" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/command/storage/eva)
 "kaL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -22042,6 +22120,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/cold/directional/south,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "kbn" = (
@@ -22096,6 +22177,9 @@
 /area/security/brig)
 "kbU" = (
 /obj/machinery/light/cold/directional/east,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "kbW" = (
@@ -22351,6 +22435,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/science/mixing/chamber)
+"khk" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "khw" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/tile/green{
@@ -22373,9 +22467,10 @@
 /area/security/brig)
 "kie" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 5
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kif" = (
 /obj/structure/window/reinforced{
@@ -22411,9 +22506,10 @@
 /area/commons/dorms)
 "kiy" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 9
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kiO" = (
 /obj/structure/lattice,
@@ -22498,9 +22594,10 @@
 /area/ai_monitored/turret_protected/ai)
 "kjY" = (
 /obj/effect/spawner/randomcolavend,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kkh" = (
 /obj/machinery/light/directional/west,
@@ -22558,9 +22655,10 @@
 /area/science/lab)
 "kks" = (
 /obj/effect/spawner/randomsnackvend,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kkX" = (
 /obj/machinery/camera{
@@ -22608,10 +22706,6 @@
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "klB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/bounty_board/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -22674,7 +22768,7 @@
 	height = 18;
 	id = "whiteship_home";
 	name = "SS13: Auxiliary Dock, Station-Fore";
-	width = 30
+	width = 36
 	},
 /turf/open/openspace/airless,
 /area/space)
@@ -22723,13 +22817,10 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "kod" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kor" = (
@@ -22747,9 +22838,14 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal)
 "koG" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
 "koR" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -22825,15 +22921,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/commons/dorms)
-"kqK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "kqS" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -22927,15 +23014,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
-"ksC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "ksF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23317,6 +23395,12 @@
 "kyk" = (
 /turf/open/floor/iron/dark,
 /area/command/bridge)
+"kyo" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "kys" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "stationawaygate";
@@ -23443,11 +23527,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
-"kBz" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/grass/green,
-/turf/open/floor/grass,
-/area/service/hydroponics)
 "kBH" = (
 /obj/item/target,
 /obj/item/target,
@@ -23732,9 +23811,10 @@
 "kIc" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/light/directional/east,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kId" = (
 /obj/structure/window/reinforced{
@@ -23770,9 +23850,10 @@
 "kJk" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light/directional/west,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kJs" = (
 /turf/closed/wall/r_wall,
@@ -23808,6 +23889,15 @@
 /obj/machinery/light/small/red/directional/west,
 /turf/open/floor/iron,
 /area/maintenance/central/secondary)
+"kKs" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "kKw" = (
 /obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/plating,
@@ -23920,12 +24010,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
-"kMY" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/science/research)
 "kNp" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -24060,6 +24144,12 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
+"kQG" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "kQM" = (
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -24150,6 +24240,9 @@
 	c_tag = "Arrivals Hallway - Starboard Checkpoint Hall";
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kSy" = (
@@ -24211,9 +24304,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/closet/emcloset,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kTL" = (
 /obj/structure/disposalpipe/segment{
@@ -24244,11 +24338,20 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"kTR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "kTS" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kUf" = (
 /obj/structure/window{
@@ -24293,9 +24396,10 @@
 /area/service/hydroponics)
 "kUI" = (
 /obj/effect/spawner/randomcolavend,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "kUT" = (
 /obj/item/kirbyplants/random,
@@ -24587,6 +24691,12 @@
 /area/space/nearstation)
 "laA" = (
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/science/research)
 "laE" = (
@@ -24630,6 +24740,12 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"lcy" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "lcJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -24674,10 +24790,11 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "ldm" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/firecloset,
 /obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/science/research)
 "ldo" = (
@@ -24782,6 +24899,18 @@
 /obj/machinery/duct,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"lfm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "lfw" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -24801,6 +24930,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
+"lfS" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "lfT" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24811,16 +24947,6 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/glass,
 /area/service/hydroponics)
-"lgI" = (
-/obj/effect/landmark/start/cargo_technician,
-/obj/structure/chair/office{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "lgM" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
@@ -24855,14 +24981,16 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "lhd" = (
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lhh" = (
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lhq" = (
 /obj/machinery/computer/rdconsole{
@@ -25096,9 +25224,12 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lkZ" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/hallway/secondary/entry)
 "lla" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -25132,6 +25263,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"llJ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "llN" = (
 /obj/machinery/light/directional/west,
 /obj/effect/mapping_helpers/iannewyear,
@@ -25249,9 +25386,10 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lnn" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -25407,9 +25545,10 @@
 /area/science/xenobiology)
 "lrj" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 10
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lrl" = (
 /obj/structure/table,
@@ -25476,10 +25615,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"lsC" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/cargo/storage)
 "lsM" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -25488,13 +25623,10 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway - Lounge"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/spawner/randomcolavend,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/spawner/randomcolavend,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lti" = (
@@ -25605,6 +25737,15 @@
 /obj/machinery/vending/games,
 /turf/open/floor/iron,
 /area/commons/storage/art)
+"lvV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "lwc" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -25721,6 +25862,9 @@
 	c_tag = "Medbay - Chemistry Lower North";
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lyK" = (
@@ -25815,10 +25959,13 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "lAy" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/closet/firecloset,
 /turf/open/floor/iron/white,
 /area/science/research)
 "lAz" = (
@@ -25848,6 +25995,9 @@
 /area/command/heads_quarters/ce)
 "lBs" = (
 /obj/structure/ladder,
+/obj/structure/sign/departments/mait{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "lBt" = (
@@ -25903,13 +26053,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/sepia,
 /area/service/chapel)
-"lCt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "lCv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/engine,
@@ -26131,14 +26274,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
-"lIW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "lJj" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -26355,6 +26490,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
+"lLt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "lLu" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Maintenance";
@@ -26478,6 +26620,9 @@
 /area/cargo/warehouse)
 "lMU" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "lNh" = (
@@ -26545,6 +26690,15 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/department/cargo)
+"lNL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "lNR" = (
 /turf/closed/wall/r_wall,
 /area/security/prison/mess)
@@ -26565,6 +26719,16 @@
 /obj/structure/chair/stool,
 /turf/open/floor/iron/grimy,
 /area/security/prison/rec)
+"lOh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/research)
 "lOH" = (
 /obj/machinery/suit_storage_unit/ce,
 /obj/machinery/status_display/evac/directional/north,
@@ -26612,6 +26776,12 @@
 /area/science/research/abandoned)
 "lPB" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/research)
 "lPZ" = (
@@ -26838,6 +27008,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
+"lUh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "lUi" = (
 /obj/machinery/button/door{
 	id = "xenobio7";
@@ -26958,6 +27137,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"lVO" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "lVS" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -26984,12 +27169,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"lWg" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "lWm" = (
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -27000,6 +27179,9 @@
 /area/science/robotics/lab)
 "lWx" = (
 /obj/structure/ladder,
+/obj/structure/sign/departments/mait{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "lWB" = (
@@ -27062,16 +27244,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
-"lXJ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "lXL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -27091,14 +27263,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
-"lXP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/cargo/office)
 "lYc" = (
 /turf/open/floor/carpet/black,
 /area/security/prison/workout)
@@ -27143,6 +27307,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"lZo" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "lZv" = (
 /obj/machinery/mecha_part_fabricator/maint,
 /obj/effect/turf_decal/stripes/line{
@@ -27219,6 +27387,12 @@
 	dir = 4;
 	network = list("ss13","rd")
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/research)
 "maA" = (
@@ -27293,6 +27467,7 @@
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_y = 10
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mbq" = (
@@ -27318,6 +27493,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"mbz" = (
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "mbG" = (
 /obj/structure/sign/barsign,
 /turf/closed/wall,
@@ -27503,9 +27683,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/kirbyplants/random,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "mgf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -27633,17 +27814,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/brig)
-"miL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/red/filled/corner{
+"miT" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -27695,13 +27868,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"mke" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "mkg" = (
 /obj/machinery/requests_console{
 	department = "Crew Quarters";
@@ -27753,6 +27919,9 @@
 "mli" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mlj" = (
@@ -27794,11 +27963,10 @@
 	},
 /area/science/robotics/lab)
 "mlK" = (
-/obj/effect/turf_decal/tile/red{
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "mlW" = (
@@ -28080,6 +28248,12 @@
 /area/medical/storage)
 "mpH" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/research)
 "mpP" = (
@@ -28144,13 +28318,6 @@
 "mqy" = (
 /turf/open/floor/iron/dark,
 /area/science/misc_lab)
-"mqB" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "mqC" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/button/door{
@@ -28298,6 +28465,18 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"msV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "mtx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -28616,6 +28795,18 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/rd)
+"mAj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	name = "dorms sorting disposal pipe";
+	sortType = 26
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "mAy" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -28719,6 +28910,9 @@
 /area/command/bridge)
 "mCb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mCj" = (
@@ -28731,6 +28925,12 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
+"mCt" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "mCF" = (
 /obj/structure/sign/warning{
 	pixel_y = -32
@@ -28805,8 +29005,21 @@
 "mDZ" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/decal/cleanable/greenglow/filled,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/research)
+"mEc" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "mEj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -28824,6 +29037,12 @@
 /area/hallway/secondary/command)
 "mEs" = (
 /obj/effect/spawner/randomsnackvend,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/science/research)
 "mEA" = (
@@ -28996,13 +29215,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"mIY" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "mJd" = (
 /obj/structure/table,
 /obj/item/hfr_box/body/fuel_input,
@@ -29174,12 +29386,6 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
-"mNe" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/treatment_center)
 "mNp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -29257,6 +29463,9 @@
 /area/medical/medbay/central)
 "mOv" = (
 /obj/structure/ladder,
+/obj/structure/sign/departments/mait{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mOA" = (
@@ -29286,6 +29495,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai)
+"mOE" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "mPa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -29340,6 +29555,9 @@
 "mQe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "mQo" = (
@@ -29513,6 +29731,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "mSP" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/science/research)
 "mSQ" = (
@@ -29536,6 +29758,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled,
 /turf/open/floor/iron,
 /area/science/research)
 "mTk" = (
@@ -29678,6 +29901,14 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
+"mVa" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/security/brig)
 "mVl" = (
 /obj/structure/window{
 	dir = 8
@@ -29919,19 +30150,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
-"nbG" = (
-/obj/machinery/door/firedoor,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_one_access_txt = "5"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "ncr" = (
 /obj/structure/table,
 /obj/item/food/cheesynachos{
@@ -30001,6 +30219,9 @@
 /area/science/xenobiology)
 "ndo" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ndw" = (
@@ -30089,12 +30310,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
-"neL" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "neN" = (
 /obj/machinery/light/small/red/directional/west,
 /obj/effect/spawner/bundle/moisture_trap,
@@ -30111,6 +30326,9 @@
 	dir = 1
 	},
 /obj/machinery/status_display/ai/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "nfc" = (
@@ -30188,11 +30406,11 @@
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
 "ngk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/hallway/secondary/entry)
 "ngr" = (
 /obj/structure/table,
 /obj/item/canvas/twentythree_twentythree,
@@ -30237,9 +30455,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "ngP" = (
 /obj/structure/closet/emcloset,
@@ -30306,8 +30525,19 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
+"nia" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/cargo/office)
 "nik" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -30407,10 +30637,14 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "nkT" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/hallway/secondary/entry)
 "nld" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30421,18 +30655,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"nlj" = (
-/obj/structure/closet{
-	anchored = 1;
-	can_be_unanchored = 1;
-	name = "Patient's Belongings"
-	},
-/obj/machinery/light/cold/directional/west,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "nlv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30460,6 +30682,9 @@
 /area/maintenance/port)
 "nmG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/warning{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nmO" = (
@@ -30522,13 +30747,21 @@
 	dir = 1
 	},
 /area/security/brig)
+"nnx" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "nnF" = (
-/turf/open/floor/iron/white/side,
+/obj/effect/turf_decal/trimline/white/filled/line,
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "nnK" = (
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 6
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "nnO" = (
 /obj/structure/cable,
@@ -30558,9 +30791,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "noo" = (
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 10
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "nop" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -30830,6 +31064,9 @@
 /area/maintenance/port/fore)
 "nuu" = (
 /obj/structure/ladder,
+/obj/structure/sign/departments/mait{
+	pixel_x = -32
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "nuD" = (
@@ -31259,6 +31496,9 @@
 "nCS" = (
 /obj/machinery/light/cold/directional/west,
 /obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nDa" = (
@@ -31289,6 +31529,9 @@
 /obj/item/healthanalyzer,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
@@ -31640,9 +31883,6 @@
 /turf/open/floor/plating,
 /area/cargo/storage)
 "nHZ" = (
-/obj/structure/sign/warning/biohazard{
-	pixel_y = -30
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
@@ -31712,6 +31952,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
 /turf/open/floor/iron,
 /area/science/server)
+"nJe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "nJi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -31896,14 +32146,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"nLV" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/dark/smooth_edge{
-	dir = 8
-	},
-/area/security/brig)
 "nLW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32138,6 +32380,9 @@
 /area/tcommsat/computer)
 "nTO" = (
 /obj/machinery/status_display/ai/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nTR" = (
@@ -32170,20 +32415,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/medical/virology)
-"nUP" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/obj/item/bedsheet/medical,
-/obj/structure/bed,
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nVd" = (
@@ -32479,12 +32710,25 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"obu" = (
+/obj/structure/sign/departments/court,
+/turf/closed/wall,
+/area/security/courtroom)
 "ocl" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"ocv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "ocL" = (
 /obj/machinery/camera{
 	c_tag = "Medbay - Cryogenics";
@@ -32569,6 +32813,9 @@
 /area/science/xenobiology)
 "oes" = (
 /obj/structure/ladder,
+/obj/structure/sign/departments/mait{
+	pixel_y = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "oeJ" = (
@@ -32617,6 +32864,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/dorms)
+"ofQ" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/grass/green,
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "ofW" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -32764,12 +33016,6 @@
 /turf/open/floor/iron/grimy,
 /area/security/prison/rec)
 "ojg" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
@@ -32930,10 +33176,12 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "oln" = (
-/obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/hallway/secondary/entry)
 "olu" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	name = "n2o to primary mix";
@@ -32958,6 +33206,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
+"olQ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "olS" = (
 /obj/structure/janitorialcart,
 /turf/open/floor/plating,
@@ -33107,6 +33362,12 @@
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
+"oqB" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "oqG" = (
 /obj/machinery/button/door{
 	id = "xenobio8";
@@ -33222,6 +33483,9 @@
 	pixel_y = 7
 	},
 /obj/item/stack/cable_coil,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "ost" = (
@@ -33239,17 +33503,14 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "osx" = (
 /obj/structure/window/reinforced{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
 	},
 /obj/machinery/light/small/directional/east,
 /obj/structure/table,
@@ -33287,6 +33548,7 @@
 /obj/item/construction/plumbing,
 /obj/item/construction/plumbing,
 /obj/machinery/light/cold/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "osZ" = (
@@ -33395,6 +33657,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
+"ovg" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
+"ovw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "ovY" = (
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
@@ -33843,13 +34118,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"oFH" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "oFN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
@@ -33872,6 +34140,9 @@
 "oFW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "oFX" = (
@@ -33879,6 +34150,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "oGh" = (
@@ -33980,6 +34254,9 @@
 /area/engineering/atmos)
 "oIJ" = (
 /obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "oIL" = (
@@ -34118,12 +34395,6 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron,
 /area/command/gateway)
-"oKQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "oKR" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -34151,12 +34422,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"oLS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "oMf" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -34318,6 +34583,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"oOP" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "oOR" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -34451,10 +34727,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
-"oRG" = (
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/cargo/office)
 "oRX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34623,14 +34895,11 @@
 /area/cargo/office)
 "oVj" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/auxiliary)
 "oVl" = (
 /obj/machinery/door/airlock/security/glass{
@@ -34855,12 +35124,6 @@
 	dir = 1
 	},
 /area/security/brig)
-"oZt" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/office)
 "oZH" = (
 /turf/closed/wall/r_wall,
 /area/science/breakroom)
@@ -34987,19 +35250,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"pbY" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "pcq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
-"pct" = (
-/obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "pcD" = (
 /obj/item/reagent_containers/glass/bottle/multiver{
 	pixel_x = 7;
@@ -35440,6 +35702,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
+"pjO" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "pky" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -35464,13 +35733,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/research)
-"pln" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/cargo/qm)
 "plw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -35517,6 +35779,12 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron/white,
 /area/medical/break_room)
+"pnb" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "png" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
 	dir = 4
@@ -35531,15 +35799,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/office)
-"pnp" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "pns" = (
 /obj/item/trash/candy{
 	pixel_x = -5
@@ -35550,6 +35809,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"pnH" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "pnL" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -35672,14 +35936,14 @@
 /turf/open/openspace/airless,
 /area/space)
 "ppK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
 "ppW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -35805,12 +36069,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
-"ptf" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "ptq" = (
 /obj/structure/chair/sofa/left,
 /obj/item/toy/plush/moth,
@@ -36362,7 +36620,12 @@
 "pEg" = (
 /obj/structure/cable,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/security/checkpoint/auxiliary)
 "pEh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36375,11 +36638,11 @@
 /turf/open/openspace,
 /area/science/xenobiology)
 "pFf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/hallway/secondary/entry)
 "pFh" = (
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Central Lower";
@@ -36762,13 +37025,6 @@
 "pKH" = (
 /turf/open/floor/iron,
 /area/science/server)
-"pKN" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/cargo/storage)
 "pKU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -36794,25 +37050,12 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/art)
-"pLl" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "pLq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/central/secondary)
-"pLy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "pLM" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/line,
@@ -36860,13 +37103,10 @@
 	pixel_x = 4;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/checkpoint/auxiliary)
 "pML" = (
 /obj/effect/turf_decal/bot,
@@ -37361,13 +37601,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
-"pYK" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "pYS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/closed/wall/r_wall,
@@ -37645,15 +37878,21 @@
 /obj/structure/stairs/south,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
-"qeM" = (
-/obj/structure/chair{
+"qei" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/hallway/primary/aft)
 "qeO" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -37789,6 +38028,15 @@
 "qig" = (
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing)
+"qij" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "qio" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -38348,6 +38596,12 @@
 /obj/item/book/manual/wiki/detective,
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
+"quh" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "quy" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -38755,7 +39009,7 @@
 "qAG" = (
 /obj/effect/landmark/blobstart,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/checkpoint/auxiliary)
 "qAS" = (
 /obj/machinery/conveyor{
@@ -38815,10 +39069,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port)
-"qDh" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner,
-/turf/open/floor/iron,
-/area/cargo/storage)
+"qDp" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/virology)
 "qDt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -38837,6 +39093,12 @@
 /area/maintenance/fore)
 "qDR" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/science/research)
 "qDS" = (
@@ -38943,12 +39205,14 @@
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
 "qFF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/secondary/entry)
 "qFH" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -38974,10 +39238,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
-"qGr" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
-/turf/open/floor/iron,
-/area/cargo/office)
 "qGs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38985,22 +39245,18 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"qGz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/cryo)
 "qGL" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/science/mixing)
+"qGM" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "qGQ" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -39181,10 +39437,7 @@
 /turf/open/floor/iron,
 /area/security/prison/safe)
 "qLE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "qLI" = (
@@ -39215,6 +39468,9 @@
 "qMk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -39255,11 +39511,9 @@
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "qNN" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "qNS" = (
 /obj/structure/closet/emcloset{
 	anchored = 1
@@ -39682,6 +39936,9 @@
 	dir = 4;
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "qVW" = (
@@ -40092,15 +40349,18 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "reS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "reW" = (
@@ -40192,6 +40452,15 @@
 "rgW" = (
 /turf/open/floor/iron/dark,
 /area/engineering/engine_smes)
+"rhd" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "rhh" = (
 /obj/structure/ladder,
 /turf/open/floor/plating,
@@ -40331,15 +40600,16 @@
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
-"rlP" = (
+"rlN" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "rlT" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -40448,9 +40718,10 @@
 "roL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "roS" = (
 /obj/effect/turf_decal/bot,
@@ -40620,6 +40891,14 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
+"rsr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "rsx" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -40654,12 +40933,6 @@
 "rsK" = (
 /turf/closed/wall,
 /area/security/prison/work)
-"rsW" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "rsX" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/machinery/light/directional/east,
@@ -40679,6 +40952,15 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"rtj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "rtA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -40909,9 +41191,10 @@
 /obj/structure/closet/firecloset{
 	anchored = 1
 	},
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "rxv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -40940,13 +41223,6 @@
 	dir = 1
 	},
 /area/security/brig)
-"rym" = (
-/obj/machinery/medical_kiosk,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "ryH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40961,15 +41237,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
-"ryW" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "ryX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/conveyor_switch/oneway{
@@ -41070,6 +41337,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
+"rAV" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "rBw" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable,
@@ -41230,7 +41504,6 @@
 /turf/open/floor/iron,
 /area/commons/storage/art)
 "rFS" = (
-/obj/machinery/status_display/evac/directional/north,
 /obj/machinery/camera{
 	c_tag = "Port Hallway - Security"
 	},
@@ -41262,9 +41535,10 @@
 /area/cargo/miningdock)
 "rHi" = (
 /obj/machinery/vending/snack/green,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "rHw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41320,13 +41594,10 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain)
 "rIx" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "rIA" = (
@@ -41374,9 +41645,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 1
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "rJi" = (
 /obj/item/shard,
@@ -41428,6 +41700,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/fore)
+"rJM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/cargo/office)
 "rJO" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
@@ -41471,6 +41751,7 @@
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/head/welding,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "rKN" = (
@@ -41643,6 +41924,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
+"rNP" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "rNQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -41653,9 +41940,6 @@
 /area/engineering/break_room)
 "rNR" = (
 /obj/machinery/light/directional/north,
-/obj/structure/sign/departments/security{
-	pixel_y = 34
-	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -41869,6 +42153,10 @@
 "rSV" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron,
 /area/science/research)
 "rTd" = (
@@ -41915,6 +42203,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"rTz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "rTD" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42102,6 +42398,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/engineering/storage/tech)
+"rXb" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "rXm" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio6";
@@ -42136,6 +42439,21 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/commons/storage/art)
+"rXO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	name = "medical sorting disposal pipe";
+	sortType = 9
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "rXY" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -42188,6 +42506,7 @@
 /obj/item/stack/ducts/fifty,
 /obj/item/plunger,
 /obj/item/plunger,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "rYP" = (
@@ -42460,10 +42779,10 @@
 /turf/open/floor/plating,
 /area/engineering/break_room)
 "sdh" = (
-/obj/machinery/light/directional/north,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "sdl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -42524,6 +42843,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/department/engine/atmos)
+"sdZ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "seb" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/bundle/costume/mafia,
@@ -42842,6 +43170,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"skU" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "skX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42942,12 +43277,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/fore)
-"sok" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "soq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43027,13 +43356,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos/experiment_room)
-"sqz" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "sqF" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
@@ -43239,6 +43561,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"stQ" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "stR" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
@@ -43300,6 +43629,11 @@
 	},
 /turf/open/floor/iron,
 /area/medical/psychology)
+"svs" = (
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "svP" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43341,12 +43675,6 @@
 /area/maintenance/department/electrical)
 "swR" = (
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
 /obj/machinery/light/small/directional/east,
 /obj/structure/table,
 /turf/open/floor/iron/white,
@@ -43943,13 +44271,6 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"sHR" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "sHS" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -44041,9 +44362,6 @@
 /area/cargo/storage)
 "sJq" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 4
-	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "sJz" = (
@@ -44083,6 +44401,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"sKk" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/science/research)
 "sKw" = (
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Control"
@@ -44407,6 +44734,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/science/mixing)
+"sQH" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "sQP" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio7";
@@ -44697,6 +45030,18 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
+"sWZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "sXd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -44885,11 +45230,6 @@
 "tbm" = (
 /turf/open/floor/iron,
 /area/maintenance/department/engine/atmos)
-"tbA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "tbC" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
@@ -44908,6 +45248,9 @@
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway - Port Checkpoint Hall";
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -45033,6 +45376,12 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"teO" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "teX" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45069,6 +45418,12 @@
 	},
 /turf/open/floor/iron,
 /area/service/theater)
+"tfn" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/command)
 "tfo" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
@@ -45089,14 +45444,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"tge" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "tgq" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/bounty_board/directional/north,
@@ -45233,6 +45580,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
+"tkE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "tkG" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/firealarm/directional/east,
@@ -45248,12 +45601,13 @@
 	c_tag = "Arrivals Hallway - Port";
 	dir = 8
 	},
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 4
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tlz" = (
-/obj/structure/sign/departments/chemistry,
+/obj/structure/sign/departments/chemistry/pharmacy,
 /turf/closed/wall,
 /area/medical/pharmacy)
 "tlB" = (
@@ -45330,15 +45684,18 @@
 /turf/open/floor/iron,
 /area/service/theater)
 "tmC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "tmG" = (
@@ -45452,6 +45809,10 @@
 /obj/effect/spawner/randomcolavend,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"tpC" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "tpF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -45642,9 +46003,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/brig)
 "tui" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/ai/directional/west,
@@ -45790,6 +46150,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/security/detectives_office/bridge_officer_office)
+"tyr" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "tyB" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/camera{
@@ -45805,12 +46169,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
-"tyW" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "tzb" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/vacuum/external{
@@ -45927,10 +46285,8 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "tBm" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/brig)
 "tBu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -45951,6 +46307,12 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/experiment_room)
+"tBw" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "tBL" = (
 /obj/machinery/camera{
 	c_tag = "Service - Bar Counter"
@@ -46064,10 +46426,6 @@
 /turf/open/floor/iron,
 /area/engineering/storage)
 "tEi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -46285,12 +46643,12 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "tJM" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
+/obj/machinery/duct,
+/obj/structure/sign/departments/restroom{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
-/area/hallway/primary/fore)
+/area/commons/dorms)
 "tKJ" = (
 /obj/machinery/door/window/northright{
 	name = "Containment Pen #7";
@@ -46313,6 +46671,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"tLl" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "tLu" = (
 /obj/structure/cable,
 /obj/machinery/duct,
@@ -46504,6 +46872,19 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/airless,
 /area/space/nearstation)
+"tQb" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
+"tQk" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "tQu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -46559,6 +46940,10 @@
 /obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
 /area/medical/storage)
+"tRo" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "tRt" = (
 /obj/structure/closet/crate/coffin,
 /obj/machinery/door/window/westleft{
@@ -46596,10 +46981,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "tSy" = (
-/obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/trimline/red/filled/line,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
 "tSE" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -46610,6 +46995,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine,
 /area/engineering/main)
+"tTp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "tTr" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "aux_base_shutters";
@@ -46709,9 +47103,10 @@
 /area/hallway/secondary/entry)
 "tUY" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 9
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "tVl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/dark/visible,
@@ -46783,15 +47178,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "tXs" = (
 /obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
-"tXF" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "tXY" = (
@@ -47288,13 +47674,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/service/library)
-"uim" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "uis" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
@@ -47467,9 +47846,10 @@
 /area/cargo/qm)
 "unr" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/iron/white/side{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 9
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "unt" = (
 /obj/machinery/light/directional/west,
@@ -47560,18 +47940,20 @@
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
+"uoE" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "uoK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/experiment_room)
-"uoZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "upg" = (
 /obj/structure/closet/crate{
 	name = "Art Crate"
@@ -47696,18 +48078,6 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/service/hydroponics)
-"usL" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/brown/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/exit)
 "usV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -47715,6 +48085,10 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"uta" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "utb" = (
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
@@ -47849,14 +48223,12 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/security/checkpoint/auxiliary)
 "uvu" = (
 /obj/machinery/door/window/eastright{
@@ -48031,7 +48403,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/checkpoint/auxiliary)
 "uAe" = (
 /obj/machinery/button/door{
@@ -48052,21 +48424,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
-"uAq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	name = "medical sorting disposal pipe";
-	sortType = 9
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "uAB" = (
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/carpet/royalblue,
@@ -48198,6 +48555,13 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"uDE" = (
+/obj/machinery/medical_kiosk,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "uDF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -48335,12 +48699,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"uIq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "uIs" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
@@ -48575,11 +48933,14 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "uMx" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "uMG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -48731,11 +49092,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
-"uQz" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/command)
+"uQv" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "uQL" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -48778,6 +49140,15 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/wood,
 /area/service/library)
+"uRz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "uSd" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
@@ -48885,6 +49256,10 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/grass,
 /area/service/hydroponics)
+"uTG" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/cargo/office)
 "uTL" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/newscaster/directional/north,
@@ -49156,12 +49531,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"vbt" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "vbA" = (
 /turf/open/floor/plating,
 /area/security/brig)
@@ -49572,6 +49941,15 @@
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
+"vjC" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "vjI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -49719,13 +50097,6 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
-"voF" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "voK" = (
 /obj/structure/table,
 /obj/item/clothing/ears/earmuffs{
@@ -49757,12 +50128,6 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"voZ" = (
-/obj/effect/turf_decal/trimline/brown/filled/warning{
-	dir = 4
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/cargo/office)
 "vpd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -49933,6 +50298,16 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vtc" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "vtN" = (
 /obj/structure/cable/layer1,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50034,12 +50409,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
-"vvM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/command)
 "vwd" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -50096,13 +50465,13 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain/private)
-"vyl" = (
-/obj/item/radio/intercom/directional/west,
-/obj/effect/turf_decal/trimline/brown/filled/line{
+"vyD" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "vyI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/iron,
@@ -50315,9 +50684,10 @@
 /area/hallway/primary/fore)
 "vDn" = (
 /obj/machinery/vending/coffee,
-/turf/open/floor/iron/white/side{
-	dir = 1
+/obj/effect/turf_decal/trimline/white/filled/line{
+	dir = 5
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "vDK" = (
 /turf/closed/wall,
@@ -50330,13 +50700,6 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
-"vEl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "vEr" = (
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #1";
@@ -50415,15 +50778,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"vGu" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "vGC" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
@@ -50450,11 +50804,10 @@
 /obj/machinery/computer/security{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
 /area/security/checkpoint/auxiliary)
 "vHB" = (
 /obj/machinery/photocopier,
@@ -50548,11 +50901,9 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "vKr" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+/obj/structure/sign/departments/security,
+/turf/closed/wall/r_wall,
+/area/security/brig)
 "vKP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50571,13 +50922,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
-"vLj" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "vLq" = (
 /turf/closed/wall/r_wall,
 /area/security/warden)
@@ -50638,6 +50982,21 @@
 /obj/structure/cable,
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
+"vNU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "vOd" = (
 /obj/structure/chair/sofa{
 	dir = 8;
@@ -50647,6 +51006,13 @@
 /obj/machinery/light/warm/directional/east,
 /turf/open/floor/wood,
 /area/service/bar)
+"vOe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "vOh" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -50691,9 +51057,10 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "vOw" = (
 /obj/machinery/conveyor{
@@ -50762,10 +51129,6 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
-"vPs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/medical/medbay/lobby)
 "vPt" = (
 /obj/structure/window{
 	dir = 4
@@ -50811,6 +51174,16 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/security/detectives_office/bridge_officer_office)
+"vQb" = (
+/obj/effect/landmark/start/cargo_technician,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "vQp" = (
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/computer/cargo/request{
@@ -50826,13 +51199,6 @@
 /obj/structure/bookcase,
 /turf/open/floor/iron,
 /area/security/prison/rec)
-"vRP" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/patients_rooms)
 "vRW" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
@@ -50852,6 +51218,19 @@
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"vSi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
+"vSj" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "vSp" = (
 /obj/machinery/suit_storage_unit/engine,
 /obj/machinery/firealarm/directional/south,
@@ -50941,13 +51320,10 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/checkpoint/auxiliary)
 "vTS" = (
 /obj/effect/turf_decal/bot,
@@ -50964,13 +51340,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
-"vTW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "vUe" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50983,6 +51352,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers,
 /turf/open/openspace/airless,
 /area/maintenance/disposal/incinerator)
+"vUu" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/cargo/office)
 "vUG" = (
 /obj/machinery/light_switch{
 	pixel_x = 22;
@@ -51139,6 +51514,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/department/engine/atmos)
+"vYu" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
+"vYw" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "vYz" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -51186,12 +51574,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
-"vZp" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "vZu" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -51211,16 +51593,6 @@
 "was" = (
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"wat" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "waQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51381,10 +51753,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/electrical)
-"weL" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "weQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
@@ -51414,12 +51782,6 @@
 	dir = 4
 	},
 /area/hallway/secondary/command)
-"wfx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/iron/white,
-/area/medical/medbay/central)
 "wfz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -51443,13 +51805,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
-"wfW" = (
-/obj/structure/flora/grass/green,
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/service/hydroponics)
 "wfY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -51478,9 +51833,10 @@
 	c_tag = "Arrivals Hallway - Starboard";
 	dir = 4
 	},
-/turf/open/floor/iron/white/side{
+/obj/effect/turf_decal/trimline/white/filled/line{
 	dir = 8
 	},
+/turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "wgk" = (
 /obj/structure/chair/sofa/corner,
@@ -51495,11 +51851,8 @@
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "wgp" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
@@ -51708,6 +52061,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "wld" = (
@@ -51797,6 +52153,10 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine/atmos)
+"wmw" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "wmy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 8
@@ -51819,13 +52179,16 @@
 	},
 /area/maintenance/department/engine/atmos)
 "wmJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/status_display/evac/directional/east,
 /obj/machinery/shower{
 	pixel_y = 15
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -51851,6 +52214,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"wna" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "wnp" = (
 /obj/structure/table/glass,
 /obj/structure/cable,
@@ -52000,10 +52369,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/security/prison/work)
-"wqw" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/service/hydroponics)
 "wqD" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/machinery/firealarm/directional/west,
@@ -52078,11 +52443,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
+"wsE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "wsQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/ai/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/science/research)
 "wtd" = (
@@ -52150,13 +52527,6 @@
 /obj/effect/spawner/bundle/costume/nyangirl,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"wuX" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "wuZ" = (
 /obj/machinery/conveyor{
 	id = "cargodelivery2";
@@ -52202,6 +52572,12 @@
 	},
 /turf/open/floor/plating,
 /area/service/library)
+"wvD" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "wvE" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -52419,10 +52795,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"wzW" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
 "wzY" = (
 /obj/machinery/door/airlock/research{
 	name = "Kill Chamber";
@@ -52535,6 +52907,12 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
+"wDz" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "wDI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -52543,6 +52921,9 @@
 /area/engineering/storage)
 "wDP" = (
 /obj/machinery/vending/medical,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "wDV" = (
@@ -52836,6 +53217,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"wLr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "wLB" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Engineering Maintenance";
@@ -52864,9 +53252,6 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "wLY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Science - Airlock";
@@ -52874,6 +53259,12 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "wMm" = (
@@ -52985,13 +53376,16 @@
 /turf/open/space/basic,
 /area/space)
 "wPv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/machinery/shower{
 	pixel_y = 15
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "wQj" = (
@@ -53101,15 +53495,6 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
-"wTs" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "wTw" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -53147,16 +53532,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/engineering/atmos/experiment_room)
-"wUq" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "wUr" = (
 /obj/machinery/camera{
 	c_tag = "Security - Firing Range";
@@ -53355,15 +53730,6 @@
 "wZN" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
-"xag" = (
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "ianroomlockdown";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/command/corporate_showroom)
 "xaD" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -53580,6 +53946,10 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/science/lab)
+"xeD" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "xeN" = (
 /obj/structure/grille,
 /obj/structure/lattice,
@@ -53602,10 +53972,6 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/science/genetics)
-"xfm" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/iron/white,
-/area/medical/storage)
 "xfy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
@@ -53824,6 +54190,9 @@
 /obj/structure/table,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "xlb" = (
@@ -53926,6 +54295,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"xob" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/science/research)
 "xod" = (
 /obj/structure/window{
 	dir = 4
@@ -54128,6 +54506,18 @@
 	},
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
+"xqI" = (
+/obj/structure/closet{
+	anchored = 1;
+	can_be_unanchored = 1;
+	name = "Patient's Belongings"
+	},
+/obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "xqJ" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -54135,6 +54525,15 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace/airless,
 /area/space/nearstation)
+"xrc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "xrf" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54380,6 +54779,10 @@
 	},
 /turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
+"xxh" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xxu" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
@@ -54837,12 +55240,6 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
-"xGJ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "xGL" = (
 /obj/structure/table/reinforced,
 /obj/item/pen,
@@ -54988,13 +55385,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
-"xKf" = (
-/obj/machinery/bounty_board/directional/south,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "xKk" = (
 /obj/structure/railing{
 	dir = 10
@@ -55099,6 +55489,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
+"xNh" = (
+/obj/machinery/bounty_board/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "xNv" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -55284,6 +55681,7 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "xRU" = (
@@ -55396,13 +55794,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
-"xUf" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "xUE" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -55467,6 +55858,14 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
+"xVt" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "xVH" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -55517,6 +55916,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
+"xWz" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "xWB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -55553,12 +55958,6 @@
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
-"xXj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/chemistry)
 "xXk" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Emitter Room";
@@ -55685,6 +56084,13 @@
 "xZx" = (
 /turf/closed/wall/r_wall,
 /area/engineering/engine_smes)
+"xZH" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "xZR" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/camera{
@@ -55795,18 +56201,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/brig)
-"ybq" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/white,
-/area/medical/storage)
-"ybS" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner,
-/turf/open/floor/iron/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "ycp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -55851,11 +56245,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"ydX" = (
-/obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/turf/open/floor/iron,
-/area/hallway/secondary/command)
 "yea" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/status_display/evac/directional/north,
@@ -56075,6 +56464,12 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
+"ykl" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "ykw" = (
 /obj/machinery/computer/prisoner/management{
 	dir = 4
@@ -56099,15 +56494,11 @@
 /turf/open/floor/iron/grimy,
 /area/maintenance/central/secondary)
 "ylL" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -70878,7 +71269,7 @@ vmS
 vmS
 aZq
 gPz
-bCN
+tug
 gJK
 eDp
 mnx
@@ -71135,7 +71526,7 @@ kQe
 vmS
 lRM
 gPz
-bCN
+tug
 tQB
 eDp
 eDp
@@ -73444,7 +73835,7 @@ qzR
 gSU
 qzR
 qzR
-amz
+sdh
 eGC
 noT
 hXl
@@ -75505,27 +75896,27 @@ jlB
 uqm
 gqD
 vXB
-cbZ
-cbZ
-cbZ
+tBm
+tBm
+tBm
 bFA
-cbZ
-cbZ
-cbZ
-cbZ
+tBm
+tBm
+tBm
+tBm
 exd
 coK
 guX
-cbZ
-cbZ
+tBm
+tBm
 wtI
 bFA
-cbZ
-cbZ
-bCN
-cbZ
-cbZ
-cFv
+tBm
+tBm
+tug
+tBm
+tBm
+ccH
 rSS
 jwV
 vRW
@@ -76039,7 +76430,7 @@ vLq
 lVq
 gVG
 iLW
-nLV
+mVa
 tUb
 pud
 xaO
@@ -77831,8 +78222,8 @@ nRq
 nRq
 vLq
 odd
-gBT
-vKr
+iuB
+bac
 vKh
 njU
 uwq
@@ -78084,11 +78475,11 @@ bgh
 guX
 rTi
 dJJ
-dWX
-dWX
+uMx
+uMx
 pHl
-glz
-gVU
+ylL
+vjC
 eRF
 pkD
 jpz
@@ -78340,12 +78731,12 @@ bxS
 eDE
 guX
 rTi
-cWe
+tSy
 qeT
 qeT
-cWe
+tSy
 vKh
-jqj
+rAV
 sCg
 hen
 dcN
@@ -78852,14 +79243,14 @@ fHp
 aGM
 sKg
 xxg
-bCN
+tug
 xhd
 gqD
 hXl
 hXl
-gqD
+vKr
 rFS
-jAO
+kQG
 dBw
 kRC
 vgF
@@ -78891,14 +79282,14 @@ xzK
 qSb
 kdY
 vKh
-gdu
+oSW
 nvb
 jGV
 jGV
 kMs
 jGV
 jGV
-nvb
+gqp
 gjw
 pyO
 dpf
@@ -79116,7 +79507,7 @@ ofZ
 mhf
 hEL
 lJL
-koG
+xeD
 dBw
 skT
 hhM
@@ -79150,12 +79541,12 @@ sNx
 vKh
 onH
 icz
-cPk
-oLS
+rNP
+nnx
 wqc
-cPk
-cPk
-icz
+rNP
+rNP
+dFZ
 rHG
 pyO
 pwP
@@ -79366,17 +79757,17 @@ gqD
 gqD
 gqD
 utb
-bCN
+tug
 bkT
 gqD
 jjp
 uKL
 hEL
 uUj
-koG
+xeD
 dBw
 kRC
-ljV
+obu
 ljV
 ljV
 ljV
@@ -79409,7 +79800,7 @@ vKh
 vKh
 vKh
 oSW
-hiZ
+lcy
 vKh
 vKh
 vKh
@@ -79623,49 +80014,49 @@ xuW
 qgZ
 gqD
 ycU
-bCN
+tug
 rTi
 gqD
 rve
 rve
 gqD
 uUj
-koG
-ylL
+xeD
+csM
 jDY
 bcQ
 aUz
-wuX
-wuX
+dkO
+dkO
 sBN
 akB
-wuX
+dkO
 owH
 hXj
 xCc
 pCR
 dmx
-wuX
+dkO
 tuB
 nZa
-wuX
+dkO
 tQu
 mgK
 kDZ
 glO
-wuX
+dkO
 iHo
-wuX
+dkO
 glO
 lop
 pCR
-wuX
+dkO
 xYS
-wuX
-wuX
-wuX
+dkO
+dkO
+dkO
 dmx
-sHR
+gmq
 exv
 lZb
 lZb
@@ -79887,7 +80278,7 @@ ofZ
 mhf
 hEL
 lJL
-koG
+xeD
 rMB
 qmR
 pGj
@@ -79923,7 +80314,7 @@ dCa
 dCa
 dCa
 dCa
-cHz
+lUh
 wcb
 wcb
 wcb
@@ -80144,9 +80535,9 @@ jjp
 fWR
 hEL
 uUj
-koG
+xeD
 wNN
-hiZ
+lcy
 dnN
 vnl
 jMO
@@ -80401,7 +80792,7 @@ rve
 rve
 gqD
 pYt
-lkZ
+djv
 cYE
 eDP
 ptG
@@ -80423,8 +80814,8 @@ nld
 hbV
 gLj
 cCP
-qFF
-ppK
+vKh
+mPa
 klB
 gjI
 tEi
@@ -80658,7 +81049,7 @@ ofZ
 mhf
 hEL
 xAy
-lkZ
+djv
 cYE
 aht
 ptG
@@ -80915,7 +81306,7 @@ jjp
 alp
 hEL
 pYt
-lkZ
+djv
 cYE
 bEP
 ptG
@@ -81429,9 +81820,9 @@ uBc
 oFu
 hYW
 sBk
-lkZ
+djv
 cYE
-eId
+fKD
 iXA
 wvC
 wcR
@@ -81686,9 +82077,9 @@ hQO
 hQO
 nMZ
 aLg
-lkZ
+djv
 lpF
-jkD
+tQb
 epS
 kJt
 fBh
@@ -81943,9 +82334,9 @@ aYF
 mJY
 jqq
 aLg
-lkZ
+djv
 cYE
-eId
+fKD
 gnj
 wvC
 wcR
@@ -81998,7 +82389,7 @@ ini
 vYk
 gdw
 vYk
-pKN
+fVu
 xCr
 oHi
 oHi
@@ -82200,7 +82591,7 @@ vHZ
 vHZ
 nsA
 rEu
-ngk
+bgS
 cYE
 ldh
 ptG
@@ -82255,7 +82646,7 @@ lER
 pep
 vBr
 jVx
-bIf
+aQn
 pdF
 ebR
 nSK
@@ -82457,7 +82848,7 @@ oCt
 mJY
 nNl
 aLg
-lkZ
+djv
 cYE
 jpD
 ptG
@@ -82507,7 +82898,7 @@ ifT
 arK
 mBo
 gHW
-gzF
+bNG
 wke
 hzX
 wke
@@ -82714,7 +83105,7 @@ oCt
 mJY
 jqq
 aLg
-lkZ
+djv
 cYE
 nKL
 ptG
@@ -82768,7 +83159,7 @@ bZg
 vFK
 eKN
 tTI
-qDh
+wmw
 fnd
 sfW
 xGo
@@ -82971,7 +83362,7 @@ uaN
 tdr
 cKh
 jeX
-nkT
+pnH
 jVl
 qEV
 ptG
@@ -83025,7 +83416,7 @@ dyk
 sHS
 djF
 oQp
-lsC
+tQk
 vEr
 sfW
 bsK
@@ -83228,9 +83619,9 @@ hQO
 hQO
 uaZ
 aLg
-lkZ
+djv
 cYE
-eId
+fKD
 ptG
 ptG
 ptG
@@ -83282,7 +83673,7 @@ xNR
 oQp
 amr
 oQp
-lsC
+tQk
 nHW
 sfW
 sLc
@@ -83485,7 +83876,7 @@ mVl
 jLY
 uqh
 nIg
-lkZ
+djv
 cYE
 aMv
 lsM
@@ -83539,7 +83930,7 @@ ksy
 oQp
 cof
 oQp
-lsC
+tQk
 jqZ
 sdD
 sdD
@@ -83742,7 +84133,7 @@ kXt
 kXt
 kXt
 kXt
-oln
+mbz
 cYE
 aMv
 qEh
@@ -83801,7 +84192,7 @@ idE
 unl
 fcf
 mZX
-pln
+jec
 sdD
 ejm
 llI
@@ -83999,9 +84390,9 @@ lnZ
 upL
 dfl
 rRj
-pFf
+wna
 cYE
-lIW
+awn
 aFY
 fhZ
 oaw
@@ -84258,7 +84649,7 @@ gHc
 ggR
 sEy
 cYE
-eId
+fKD
 nSX
 nSX
 nSX
@@ -84559,8 +84950,8 @@ jty
 kEQ
 rvi
 vgZ
-izz
-izz
+lvV
+lvV
 rTD
 oUJ
 biT
@@ -84770,7 +85161,7 @@ auH
 auH
 auH
 auH
-sdh
+rNR
 cYE
 jnK
 nSX
@@ -84818,7 +85209,7 @@ xXA
 sti
 orE
 bID
-aTa
+aMF
 rKx
 mOA
 gTH
@@ -84998,7 +85389,7 @@ xzK
 xzK
 juM
 kie
-jWP
+glz
 kTt
 cYB
 cYB
@@ -85027,9 +85418,9 @@ mNv
 pLg
 tUz
 aAB
-lkZ
+djv
 cYE
-qeM
+aop
 nSX
 nHm
 iCP
@@ -85072,7 +85463,7 @@ rIA
 wZl
 kEQ
 jwr
-qGr
+uTG
 mSQ
 ava
 uhc
@@ -85284,7 +85675,7 @@ upg
 rFE
 asc
 aAB
-lkZ
+djv
 cYE
 sKY
 nSX
@@ -85329,7 +85720,7 @@ aeF
 arm
 kEQ
 dok
-qGr
+uTG
 jSR
 kMQ
 dzG
@@ -85541,7 +85932,7 @@ lvT
 rXI
 cFK
 psL
-tug
+rXb
 cYE
 aWh
 nSX
@@ -85554,7 +85945,7 @@ qvO
 qvO
 qvO
 jep
-kBz
+ofQ
 swv
 myw
 gXJ
@@ -85563,7 +85954,7 @@ wNM
 lWB
 myp
 dHd
-wqw
+tRo
 jep
 qDV
 qZj
@@ -85798,7 +86189,7 @@ aCi
 aCi
 aCi
 aCi
-tBm
+isP
 cYE
 cZw
 qvO
@@ -85820,7 +86211,7 @@ jxZ
 jxZ
 jxZ
 lWB
-wfW
+iAr
 jep
 rDu
 qZj
@@ -85843,10 +86234,10 @@ rAj
 wDV
 kEQ
 sPw
-qGr
+uTG
 jSR
 rJl
-gJC
+uoE
 hTJ
 qAD
 qAD
@@ -86026,7 +86417,7 @@ xzK
 xzK
 juM
 tUY
-jWP
+gBT
 jWP
 rnF
 piC
@@ -86055,7 +86446,7 @@ aeQ
 gxl
 vqx
 aCi
-lkZ
+djv
 dbk
 sbg
 qvO
@@ -86100,7 +86491,7 @@ rAj
 qTX
 kEQ
 xyF
-qGr
+uTG
 oPC
 pMl
 uhc
@@ -86312,9 +86703,9 @@ anE
 ank
 cDD
 aCi
-tJM
+jcO
 cYE
-eId
+fKD
 qvO
 qvO
 kQi
@@ -86357,8 +86748,8 @@ rAj
 xQi
 kEQ
 udc
-lgI
-oZt
+vQb
+pnb
 eIb
 gNX
 gAG
@@ -86569,9 +86960,9 @@ anE
 dWR
 aub
 rLT
-lkZ
+djv
 drE
-uoZ
+iDn
 lXu
 cGA
 bhc
@@ -86776,6 +87167,7 @@ jtc
 juq
 jAX
 jAX
+bCN
 jYe
 jYe
 jYe
@@ -86783,19 +87175,18 @@ jYe
 jYe
 jYe
 jYe
-jYe
-jYe
+cWe
 jAX
 jAX
 tlo
+bCN
 jYe
 jYe
-jYe
-jYe
+cWe
 jAX
 jAX
 ici
-jYe
+bCN
 jYe
 jYe
 tzx
@@ -86828,7 +87219,7 @@ ctf
 uLp
 gpo
 aOu
-eId
+fKD
 cvA
 vig
 soq
@@ -86872,8 +87263,8 @@ hZB
 kEQ
 xIJ
 gYt
-hfP
-ggm
+jfn
+nia
 nrd
 gJY
 aRJ
@@ -87083,9 +87474,9 @@ afq
 anE
 ewR
 rLT
-lkZ
+djv
 cYE
-iiL
+dQN
 ddR
 rlM
 bFI
@@ -87310,8 +87701,8 @@ juM
 hOp
 juM
 vDn
-jWP
-jYe
+lhd
+bCN
 jYe
 unt
 wyp
@@ -87340,9 +87731,9 @@ anE
 anE
 dAi
 aCi
-sdh
+rNR
 vDm
-uoZ
+iDn
 aOf
 hdm
 dWi
@@ -87383,8 +87774,8 @@ mbG
 iKd
 rAj
 qTX
-mqB
-iXy
+sJq
+gmF
 tcF
 gMD
 ndy
@@ -87570,13 +87961,13 @@ juM
 juM
 roL
 jWP
-jWP
-vwd
-jWP
+jAO
+lkZ
+ngk
 tbM
-xiZ
+oln
 qMk
-jWP
+pFf
 rNx
 syU
 xFO
@@ -87599,7 +87990,7 @@ cxR
 aCi
 hKB
 cYE
-eId
+fKD
 sZa
 kvT
 sTR
@@ -87641,7 +88032,7 @@ iKd
 rAj
 qTX
 sJq
-iXy
+gmF
 hIs
 pgQ
 hIs
@@ -87854,9 +88245,9 @@ anE
 anE
 hxZ
 aCi
-tSy
+svs
 cYE
-eId
+fKD
 vjk
 qvO
 kvT
@@ -87899,8 +88290,8 @@ ioh
 kzn
 bex
 jLe
-voZ
-lXP
+vUu
+rJM
 dNg
 pjL
 gJY
@@ -88111,9 +88502,9 @@ gIr
 rLT
 aCi
 sbV
-uMx
-miL
-pct
+iQu
+vNU
+eDa
 lkd
 hHC
 kvi
@@ -88134,9 +88525,9 @@ nJE
 kZP
 eLu
 siC
-kqK
-dTS
-dTS
+ocv
+mCt
+mCt
 qbB
 owR
 owR
@@ -88156,7 +88547,7 @@ rAj
 qTX
 dNH
 evS
-oRG
+sJq
 lww
 ebu
 kEQ
@@ -88370,7 +88761,7 @@ aLg
 aHj
 aLg
 mdq
-pYK
+skU
 gld
 mrG
 pCH
@@ -88405,20 +88796,20 @@ tGv
 dHg
 xXd
 ohs
-vyl
+gXp
 kqS
-qNN
+imJ
 nsT
 sTo
 bZU
 nAR
 dlq
-rsW
+jXY
 aCB
 wld
-rsW
+jXY
 pUA
-rsW
+jXY
 xaZ
 bmI
 aeV
@@ -88628,7 +89019,7 @@ qHL
 eMN
 oFT
 fnX
-iSm
+lfm
 psv
 pDp
 pDp
@@ -88665,10 +89056,10 @@ pDp
 pDp
 psv
 pDp
-dIN
-ijG
+fms
+qei
 hlm
-usL
+sWZ
 xdx
 hop
 hop
@@ -88884,7 +89275,7 @@ aLg
 aHj
 aLg
 deu
-hFJ
+tLl
 pOK
 abe
 nfQ
@@ -88894,10 +89285,10 @@ jBW
 eJc
 pOT
 ezV
-pLl
+wsE
 fPY
-uIq
-pLl
+lVO
+wsE
 pOT
 pOT
 kUT
@@ -88927,14 +89318,14 @@ uft
 olF
 wyT
 bNv
-czs
+iKH
 xDG
 kPx
-czs
-czs
+iKH
+iKH
 iSg
 fTd
-czs
+iKH
 chu
 adT
 adT
@@ -89141,7 +89532,7 @@ xxF
 juN
 pXj
 mwX
-xUf
+lfS
 tlz
 oaK
 oaK
@@ -89151,7 +89542,7 @@ rKn
 xqz
 aiO
 aiO
-aQj
+bRj
 nGq
 bRj
 aiO
@@ -89183,7 +89574,7 @@ iKd
 rAj
 slB
 wha
-eHe
+kaE
 mwQ
 oDN
 mwQ
@@ -89398,7 +89789,7 @@ baH
 xxF
 hKv
 ojD
-mIY
+miT
 oaK
 iwT
 suE
@@ -89418,8 +89809,8 @@ pJR
 ghF
 muu
 hBI
-gnr
-nlj
+clv
+xqI
 hVB
 bzx
 bzx
@@ -89626,13 +90017,13 @@ juM
 juM
 rJb
 rNx
-rNx
+koG
 wlc
-rNx
+nkT
 kSn
 gHI
-dox
-dox
+ppK
+qFF
 dox
 jJj
 pKp
@@ -89675,7 +90066,7 @@ pJR
 sMF
 iAD
 blD
-fTo
+vSi
 wjv
 hVB
 bzx
@@ -89859,7 +90250,7 @@ cYB
 cYB
 juM
 hOp
-juM
+amz
 kiy
 kks
 kJk
@@ -89880,8 +90271,8 @@ juM
 hOp
 juM
 unr
-jWP
-rNx
+lhh
+gVU
 jWP
 mZx
 vwd
@@ -89912,7 +90303,7 @@ tve
 xxF
 fTM
 ojD
-xKf
+xNh
 oaK
 wnp
 eYV
@@ -89922,17 +90313,17 @@ csJ
 mMY
 kNQ
 blh
-pLy
+ovw
 uDi
 lVt
-lCt
+eqd
 vgV
 hek
 pJR
 hco
 wGv
 iSe
-dja
+oOP
 onp
 hVB
 wFJ
@@ -90116,7 +90507,7 @@ hWn
 fec
 juM
 jJG
-juM
+amz
 jZg
 jWP
 jWP
@@ -90169,7 +90560,7 @@ baH
 xxF
 gnj
 ojD
-oKQ
+tBw
 oaK
 xrv
 rBw
@@ -90177,13 +90568,13 @@ hbr
 mNy
 pYy
 mMY
-chv
+qNN
 sCH
 uZQ
 oze
 gle
-rym
-voF
+uDE
+xZH
 wdQ
 pJR
 wVK
@@ -90374,6 +90765,7 @@ jtQ
 jva
 jKS
 jKS
+cbZ
 jYe
 jYe
 jYe
@@ -90381,19 +90773,18 @@ jYe
 jYe
 jYe
 jYe
-jYe
-jYe
+dWX
 jKS
 jKS
 wgc
+cbZ
 jYe
 jYe
-jYe
-jYe
+dWX
 jKS
 jKS
 ngN
-jYe
+cbZ
 jYe
 jYe
 gqG
@@ -90436,7 +90827,7 @@ gbs
 oZL
 rgC
 bCb
-bPt
+tkE
 ofE
 bZp
 dXk
@@ -90447,7 +90838,7 @@ aXi
 lYk
 qSY
 lYk
-vRP
+mEc
 hVB
 dZR
 bzx
@@ -90691,20 +91082,20 @@ fmt
 tky
 oaK
 jst
-vPs
+tyr
 uLQ
 iDV
 mzr
 nmY
 xUE
-sqz
+byb
 vYb
 pJR
 xbp
 oEw
 eqN
 pev
-ksC
+fGW
 hVB
 phH
 aYA
@@ -90725,7 +91116,7 @@ xST
 wYk
 nTR
 oyc
-vvM
+tfn
 jps
 xiU
 efx
@@ -90940,7 +91331,7 @@ vaX
 xxF
 dKP
 ojD
-oKQ
+tBw
 oaK
 oaK
 dHc
@@ -90948,14 +91339,14 @@ wib
 csJ
 oaK
 bbg
-nbG
+dDH
 qHf
 wzm
 vTL
 dbS
 wRp
 jDJ
-nbG
+dDH
 pJR
 pJR
 pJR
@@ -90987,11 +91378,11 @@ cFU
 mrX
 kyW
 ota
-ckH
-vbt
-vbt
-vbt
-hga
+ekX
+bOx
+bOx
+bOx
+ovg
 ldg
 jsw
 bXb
@@ -91166,7 +91557,7 @@ xzK
 xzK
 juM
 fba
-jWP
+glz
 jWP
 fec
 xzK
@@ -91189,7 +91580,7 @@ wdw
 uiW
 snh
 gOj
-via
+tJM
 xxF
 elw
 uwM
@@ -91197,22 +91588,22 @@ jpd
 xxF
 eiL
 skX
-oKQ
+tBw
 gnj
 eAc
 syJ
 iEp
 iEp
 vFI
-dhf
-lWg
+iIu
+xWz
 rjN
 iEp
 lHZ
 iEp
 esB
-hew
-lWg
+dVp
+xWz
 dbK
 sJG
 iEp
@@ -91221,7 +91612,7 @@ dIF
 jqD
 iEp
 aLz
-cnf
+xVt
 rlT
 phA
 aiw
@@ -91248,7 +91639,7 @@ cJC
 oxT
 kPl
 aWN
-its
+oqB
 xsR
 qrY
 dMd
@@ -91453,25 +91844,25 @@ xxF
 xvy
 xxF
 fUd
-uAq
-uim
+rXO
+pjO
 mxv
 raq
 ttC
-wat
-wat
+rlN
+rlN
 rds
 oxR
 uyT
 uSj
 lMm
 lMm
-ryW
+qij
 sBW
 vjI
 wHy
 pUu
-jPh
+fsh
 fWj
 wQT
 wfz
@@ -91505,9 +91896,9 @@ clG
 clG
 clG
 clG
-its
+oqB
 ari
-ydX
+cuw
 bXb
 iOL
 tAF
@@ -91711,7 +92102,7 @@ jUN
 xxF
 aLg
 ojD
-oKQ
+tBw
 bDY
 bDY
 bDY
@@ -91734,8 +92125,8 @@ hPH
 hPH
 hPH
 cJP
-weL
-xXj
+uta
+teO
 fir
 tvl
 tvl
@@ -91762,7 +92153,7 @@ mQx
 oum
 ifD
 clG
-its
+oqB
 ari
 tCH
 bXb
@@ -91976,7 +92367,7 @@ fwR
 hIe
 oZO
 xAE
-bot
+ipX
 dvO
 pKc
 cDx
@@ -91991,7 +92382,7 @@ sIa
 dgU
 hPH
 vdc
-mke
+eNp
 bbU
 kfg
 iLh
@@ -92019,7 +92410,7 @@ lsB
 qbm
 gAC
 clG
-its
+oqB
 ari
 nEP
 bXb
@@ -92194,7 +92585,7 @@ xzK
 xzK
 juM
 kiy
-mZx
+jqj
 smR
 fec
 aHn
@@ -92225,7 +92616,7 @@ xxF
 xxF
 aLg
 skX
-oKQ
+tBw
 bDY
 ptq
 gzc
@@ -92233,7 +92624,7 @@ rwZ
 dZj
 bDY
 diY
-bot
+ipX
 jSV
 cxV
 kFO
@@ -92248,8 +92639,8 @@ wti
 khf
 hPH
 nCM
-weL
-xXj
+uta
+teO
 bpq
 fBK
 qnM
@@ -92276,9 +92667,9 @@ mWB
 xJg
 tmG
 qVa
-pnp
+uRz
 ari
-fLD
+lZo
 bXb
 bRU
 ftH
@@ -92481,8 +92872,8 @@ lVS
 ePO
 bbt
 ojA
-ery
-oKQ
+mAj
+tBw
 svr
 vYB
 udV
@@ -92490,7 +92881,7 @@ xQk
 sTi
 bDY
 wvi
-bot
+ipX
 jSV
 cxV
 fwt
@@ -92505,8 +92896,8 @@ wti
 mUi
 hPH
 ljg
-weL
-xXj
+uta
+teO
 bpq
 fBK
 bBK
@@ -92523,7 +92914,7 @@ xTI
 gEE
 rAj
 qjw
-xag
+iwR
 lGf
 uAB
 hKl
@@ -92535,7 +92926,7 @@ wIX
 clG
 isV
 ari
-ydX
+cuw
 whG
 gkc
 whG
@@ -92747,7 +93138,7 @@ bDY
 bDY
 bDY
 rYy
-bot
+ipX
 jSV
 cxV
 hwV
@@ -92762,8 +93153,8 @@ mwf
 oTW
 hPH
 rXr
-weL
-xXj
+uta
+teO
 bpq
 fBK
 bBK
@@ -92780,7 +93171,7 @@ xTI
 iKd
 rAj
 qjw
-xag
+iwR
 tTE
 tHj
 eCG
@@ -93003,7 +93394,7 @@ jwu
 wyV
 mgD
 din
-diY
+cUx
 gBS
 voL
 xkn
@@ -93019,8 +93410,8 @@ hPH
 hPH
 hPH
 fsz
-weL
-xXj
+uta
+teO
 bpq
 fBK
 kns
@@ -93038,7 +93429,7 @@ nKE
 ioh
 ybg
 tEb
-xag
+iwR
 eFP
 tEb
 vyK
@@ -93047,7 +93438,7 @@ clG
 clG
 clG
 clG
-cWb
+olQ
 wLp
 ocl
 whG
@@ -93253,7 +93644,7 @@ wox
 xZg
 aLg
 ojD
-oKQ
+tBw
 bDY
 plH
 gSc
@@ -93273,11 +93664,11 @@ txa
 mOs
 iEp
 iEp
-dJv
-dJv
-dJv
-lWg
-xXj
+rtj
+rtj
+rtj
+xWz
+teO
 bpq
 ceG
 qnM
@@ -93306,7 +93697,7 @@ ora
 oJQ
 mEk
 ngL
-fLD
+lZo
 whG
 scC
 nwe
@@ -93530,11 +93921,11 @@ arc
 pAc
 pAc
 aba
-hkT
+msV
 fki
 nzl
-wfx
-jfv
+vSj
+wDz
 bmZ
 uyN
 qnM
@@ -93561,7 +93952,7 @@ ewO
 iaY
 ora
 fgy
-its
+oqB
 ari
 ikV
 whG
@@ -93777,7 +94168,7 @@ hmb
 ozs
 rdy
 jSV
-caw
+stQ
 dnx
 fZB
 qGs
@@ -93818,7 +94209,7 @@ mkx
 pUa
 ora
 mQL
-its
+oqB
 ari
 pfQ
 whG
@@ -94024,7 +94415,7 @@ wox
 xZg
 aLg
 ojD
-gou
+jns
 bDY
 mpq
 jJA
@@ -94036,9 +94427,9 @@ hxo
 dvO
 icy
 xEC
-mNe
-lXJ
-aTk
+pbY
+khk
+vyD
 lTq
 wEP
 vAU
@@ -94075,7 +94466,7 @@ cpJ
 viX
 ora
 chN
-its
+oqB
 ari
 rvE
 fKw
@@ -94284,11 +94675,11 @@ ojD
 wAI
 bDY
 rhN
-ybq
+iVS
 uPM
 uPM
 nLW
-oFH
+gXb
 xsy
 bbR
 gYJ
@@ -94332,7 +94723,7 @@ cSH
 eVX
 ora
 qxp
-its
+oqB
 ari
 lIT
 fKw
@@ -94552,7 +94943,7 @@ fvb
 rAN
 cpL
 oyw
-qGz
+nJe
 aLE
 wEP
 eEA
@@ -94591,7 +94982,7 @@ ora
 oMf
 mEk
 ari
-fLD
+lZo
 ngd
 jaW
 spQ
@@ -94795,12 +95186,12 @@ wox
 sEg
 aLg
 ojD
-oKQ
+tBw
 bDY
 qiI
 jtY
-xfm
-dcK
+iXo
+uQv
 hya
 xoT
 hmb
@@ -94846,7 +95237,7 @@ ora
 mJS
 ora
 kDD
-its
+oqB
 ari
 hfd
 iRK
@@ -95099,13 +95490,13 @@ qZB
 xQU
 kyW
 oDD
-vLj
-rlP
+vYu
+xrc
 wjI
-sok
+ire
 vOq
 ari
-fLD
+lZo
 ihd
 vAo
 jRW
@@ -95351,7 +95742,7 @@ vFM
 nEW
 dGu
 kdm
-uQz
+bNl
 ggU
 xSf
 hmf
@@ -95362,7 +95753,7 @@ dmh
 dmh
 dmh
 ctE
-fLD
+lZo
 mPh
 aFd
 hTS
@@ -95566,7 +95957,7 @@ xZg
 sEg
 pdL
 yjl
-uim
+pjO
 xmY
 npc
 npc
@@ -95614,12 +96005,12 @@ pdM
 hEJ
 oza
 jso
-wTs
-wTs
-wTs
-wTs
-jFT
-fLD
+eMb
+eMb
+eMb
+eMb
+lNL
+lZo
 lVL
 aRh
 vAo
@@ -95823,7 +96214,7 @@ rWo
 gvk
 aLg
 lJV
-oKQ
+tBw
 xTI
 xTI
 xTI
@@ -95876,7 +96267,7 @@ eAq
 kFL
 feR
 wfu
-fLD
+lZo
 nxX
 xhr
 pHb
@@ -96080,7 +96471,7 @@ lBw
 qje
 auJ
 ttT
-cMs
+wvD
 xOt
 ihy
 gyV
@@ -96133,7 +96524,7 @@ bCp
 tya
 rhX
 nxe
-fLD
+lZo
 mBT
 vAo
 tmm
@@ -96337,7 +96728,7 @@ sEg
 sEg
 jKr
 rQZ
-wUq
+vtc
 sGS
 xIk
 xIk
@@ -96596,30 +96987,30 @@ aLZ
 dbT
 xYU
 htM
-idh
-idh
-idh
-idh
+qGM
+qGM
+qGM
+qGM
 wLg
-idh
+qGM
 htM
-idh
+qGM
 kTL
-idh
-idh
-idh
+qGM
+qGM
+qGM
 wTV
 xmh
-idh
+qGM
 wLg
 wLg
-idh
+qGM
 rQU
-idh
+qGM
 iJL
-idh
-idh
-xGJ
+qGM
+qGM
+bpX
 bTq
 jMb
 oMn
@@ -96647,7 +97038,7 @@ iNP
 laP
 izZ
 eIN
-ydX
+cuw
 sGE
 jaW
 spQ
@@ -96874,7 +97265,7 @@ wwP
 eVP
 nzg
 fOC
-vGu
+kKs
 ksN
 fjg
 shv
@@ -97401,7 +97792,7 @@ ndj
 vrp
 qAm
 kxa
-ixl
+sdZ
 wWE
 wEM
 agx
@@ -97656,9 +98047,9 @@ uff
 rzo
 rzo
 xJJ
-neL
+kyo
 psE
-wzW
+tpC
 vgD
 rzo
 rzo
@@ -97913,9 +98304,9 @@ uff
 rzo
 rzo
 xJJ
-neL
+kyo
 psE
-wzW
+tpC
 vgD
 rzo
 rzo
@@ -98170,9 +98561,9 @@ ogK
 hrw
 xKk
 xJJ
-neL
+kyo
 psE
-wzW
+tpC
 vgD
 wWB
 hrw
@@ -98427,9 +98818,9 @@ wxR
 wxR
 uff
 hwf
-neL
+kyo
 psE
-wzW
+tpC
 amX
 xyZ
 wxR
@@ -98660,7 +99051,7 @@ gPI
 oDz
 aDe
 vgr
-cZv
+tmC
 sfR
 nYL
 nYL
@@ -98684,9 +99075,9 @@ wxR
 wxR
 uff
 fss
-vTW
+vOe
 yaX
-vEl
+wLr
 fzC
 xyZ
 wxR
@@ -98919,10 +99310,10 @@ cDr
 deD
 fkS
 qPx
-iek
-iek
-iek
-kMY
+llJ
+llJ
+llJ
+iuU
 kLf
 ojW
 ygP
@@ -98941,9 +99332,9 @@ gDv
 agx
 ndj
 xJJ
-neL
+kyo
 yaX
-wzW
+tpC
 vgD
 wEM
 agx
@@ -99178,7 +99569,7 @@ mWX
 eIz
 uIW
 teX
-iki
+tTp
 geF
 nhG
 vKV
@@ -99198,9 +99589,9 @@ uff
 rzo
 rzo
 xJJ
-neL
+kyo
 yaX
-wzW
+tpC
 vgD
 rzo
 rzo
@@ -99455,9 +99846,9 @@ uff
 rzo
 rzo
 xJJ
-neL
+kyo
 yaX
-wzW
+tpC
 vgD
 rzo
 rzo
@@ -99712,9 +100103,9 @@ ogK
 hrw
 xKk
 xJJ
-neL
+kyo
 yaX
-wzW
+tpC
 vgD
 wWB
 hrw
@@ -99969,9 +100360,9 @@ wxR
 wxR
 uff
 xJJ
-neL
+kyo
 yaX
-wzW
+tpC
 vgD
 xyZ
 wxR
@@ -100207,11 +100598,11 @@ svg
 hQF
 fVo
 lcJ
-imE
-iek
-iek
-iek
-iek
+gcl
+llJ
+llJ
+llJ
+llJ
 vPQ
 gur
 nvx
@@ -100226,9 +100617,9 @@ vrS
 sbE
 maM
 jZF
-neL
+kyo
 yaX
-wzW
+tpC
 uPw
 ftU
 ftU
@@ -100471,7 +100862,7 @@ teX
 teX
 teX
 teX
-iki
+tTp
 tQM
 tzi
 gwz
@@ -100479,13 +100870,13 @@ gzN
 gOE
 tbC
 phN
-gef
-gef
-gef
-gef
-tge
+rTz
+rTz
+rTz
+rTz
+gLt
 pDK
-wzW
+tpC
 liy
 lul
 lul
@@ -100526,9 +100917,9 @@ nxB
 uyr
 wGV
 dWL
-vZp
+sQH
 eOt
-ybS
+xxh
 dWL
 wyy
 wyy
@@ -100734,15 +101125,15 @@ fRH
 iIM
 gAX
 gPM
-nWO
+atU
 okO
 ous
 oHL
 buD
 phS
-ptf
+iWs
 yaX
-tbA
+glA
 lqO
 lAp
 lAp
@@ -100999,7 +101390,7 @@ nWO
 nWO
 jDf
 pEh
-wzW
+tpC
 qaZ
 qoa
 qoa
@@ -101254,9 +101645,9 @@ wxR
 wxR
 uff
 piK
-neL
+kyo
 pEh
-wzW
+tpC
 lrp
 mam
 mmq
@@ -101491,7 +101882,7 @@ cFd
 pdz
 qAs
 oay
-bCj
+iAO
 rKk
 xms
 rdk
@@ -101511,9 +101902,9 @@ wxR
 wxR
 uff
 piZ
-neL
+kyo
 pEh
-wzW
+tpC
 qbt
 qbt
 qbt
@@ -101768,9 +102159,9 @@ ouH
 wxR
 uff
 piZ
-neL
+kyo
 pEh
-wzW
+tpC
 qxj
 qxj
 qxj
@@ -102025,9 +102416,9 @@ wxR
 wxR
 uff
 piZ
-neL
+kyo
 pEh
-wzW
+tpC
 qxj
 qxj
 qxj
@@ -102282,9 +102673,9 @@ wxR
 wxR
 uff
 iXS
-neL
+kyo
 pEh
-wzW
+tpC
 qxj
 qxj
 qxD
@@ -102541,9 +102932,9 @@ nWO
 nWO
 pup
 pFq
-aOa
-tyW
-ebQ
+ykl
+bAU
+gTL
 nWO
 nWO
 tgs
@@ -102796,11 +103187,11 @@ xwg
 xwg
 oSV
 nWO
-tXF
+dKA
 pFX
 qGd
-epN
-hht
+bXR
+rhd
 nWO
 evM
 tgs
@@ -154964,7 +155355,7 @@ nCS
 qVA
 nTO
 gTx
-osh
+qDp
 fsD
 kCy
 pdO
@@ -155221,8 +155612,8 @@ osh
 osh
 nUl
 nUl
-oFW
-oFW
+kTR
+jjj
 kgw
 knQ
 iSN
@@ -155474,9 +155865,9 @@ vXc
 kCy
 jCo
 nmG
-nmG
+lLt
 oFW
-nUl
+iaX
 fja
 oss
 kbd
@@ -156247,7 +156638,7 @@ aoe
 ndG
 nmT
 nDo
-nUP
+ojg
 swR
 osx
 ojg
@@ -157780,14 +158171,14 @@ xPX
 xmR
 vXc
 tvl
-qnM
+quh
 lMU
 oIJ
-qnM
+aXF
 jYL
-mPZ
+rsr
 nfb
-qnM
+gdG
 tvl
 tvl
 tvl
@@ -158037,14 +158428,14 @@ xPX
 vsw
 vXc
 tvl
-qnM
+fBK
 qnM
 qnM
 qnM
 qnM
 mPZ
 qnM
-qnM
+eTD
 osP
 rCJ
 rCJ
@@ -158294,17 +158685,17 @@ xPX
 rPt
 kXd
 tvl
-qnM
+fBK
 qnM
 qnM
 qnM
 qnM
 mPZ
 qnM
-qnM
+vYw
 mli
-qnM
-qnM
+eCP
+eCP
 lMU
 xkN
 tvl
@@ -158551,7 +158942,7 @@ xPX
 vXc
 vXc
 tvl
-qnM
+fBK
 qnM
 qnM
 qnM
@@ -158808,7 +159199,7 @@ xPX
 xmR
 xmR
 tvl
-qnM
+fBK
 qnM
 qnM
 qnM
@@ -159322,7 +159713,7 @@ xPX
 xNO
 vsw
 tvl
-qnM
+fBK
 qnM
 qnM
 qnM
@@ -159579,7 +159970,7 @@ xPX
 vWQ
 vWQ
 tvl
-qnM
+fBK
 qnM
 qnM
 qnM
@@ -159836,7 +160227,7 @@ xPX
 vXc
 xmR
 tvl
-qnM
+fBK
 qnM
 qnM
 qnM
@@ -159848,7 +160239,7 @@ qnM
 qnM
 qnM
 qnM
-qnM
+eTD
 tvl
 xPX
 xPX
@@ -160093,7 +160484,7 @@ xPX
 vXc
 snT
 tvl
-qnM
+fBK
 qnM
 qnM
 qnM
@@ -160105,7 +160496,7 @@ qnM
 qnM
 qnM
 qnM
-qnM
+eTD
 tvl
 ymg
 ymg
@@ -160350,19 +160741,19 @@ xPX
 xmR
 xmR
 tvl
-qnM
+mOE
 hBc
 kbU
-qnM
+cFa
 mCb
 mQe
 nhV
-qnM
+cFa
 kbU
-qnM
-qnM
+cFa
+cFa
 hBc
-qnM
+vhT
 tvl
 ymg
 ymg
@@ -165752,7 +166143,7 @@ lPB
 max
 mpH
 mDZ
-mSP
+xob
 iIM
 nrF
 nHA
@@ -166005,11 +166396,11 @@ vXc
 iIM
 mSP
 mTd
-mTd
-mTd
+cIy
+bUb
 wsQ
-mTd
-mTd
+hzR
+lOh
 nfX
 nrJ
 nHJ
@@ -166261,8 +166652,8 @@ rTv
 vsw
 iIM
 laA
-mTd
-mSP
+bUb
+sKk
 maA
 mpP
 mEs
@@ -166270,9 +166661,9 @@ qDR
 iIM
 nss
 nHZ
-nWO
+atU
 tBU
-ioF
+idn
 psE
 oSQ
 tXs

--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -30,28 +30,25 @@
 /area/maintenance/department/cargo)
 "aba" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "abe" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /obj/machinery/bluespace_vendor/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "abD" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "abM" = (
@@ -127,6 +124,9 @@
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
 "adT" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -137,13 +137,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "aet" = (
-/obj/effect/turf_decal/tile/green{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aeF" = (
@@ -163,10 +160,10 @@
 /turf/open/floor/iron/dark,
 /area/commons/storage/primary)
 "aeV" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -223,10 +220,13 @@
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
 "aht" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -244,11 +244,13 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "ahF" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ahZ" = (
@@ -323,12 +325,12 @@
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
 "aiV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "ajb" = (
@@ -406,8 +408,7 @@
 "ajy" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -443,6 +444,9 @@
 "akB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "akI" = (
@@ -506,15 +510,10 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "amz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "amM" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
@@ -550,15 +549,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"anc" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "ank" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -640,7 +630,7 @@
 /area/command/teleporter)
 "aqo" = (
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "aqz" = (
 /obj/structure/cable,
@@ -668,6 +658,9 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "ari" = (
@@ -680,16 +673,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
 "arm" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/structure/table,
 /obj/item/trash/can/food/beans,
 /obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "arn" = (
@@ -717,6 +704,9 @@
 	dir = 8
 	},
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "arP" = (
@@ -735,32 +725,14 @@
 /area/commons/storage/art)
 "asm" = (
 /obj/machinery/airalarm/directional/south,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay - Treatment Center";
 	dir = 1;
 	network = list("ss13","medbay")
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"asw" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	name = "cmo sorting disposal pipe";
-	sortType = 10
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "asy" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -794,17 +766,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
-"ats" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "att" = (
 /obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron,
@@ -816,11 +777,11 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "auA" = (
+/obj/effect/landmark/start/hangover,
 /obj/structure/chair/sofa{
 	dir = 1;
 	name = "plush sofa"
 	},
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/service/bar)
 "auH" = (
@@ -847,15 +808,13 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "ava" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/effect/landmark/start/cargo_technician,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "avu" = (
@@ -880,10 +839,6 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "awh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera{
 	c_tag = "Medbay - Lobby";
 	dir = 1;
@@ -891,6 +846,7 @@
 	},
 /obj/item/kirbyplants,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "awr" = (
@@ -1029,14 +985,11 @@
 /turf/open/floor/plating,
 /area/commons/storage/art)
 "aAD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/firealarm/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "aAH" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
@@ -1079,12 +1032,11 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "aBO" = (
@@ -1101,15 +1053,11 @@
 /turf/open/floor/wood,
 /area/command/corporate_showroom)
 "aCB" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "aCE" = (
@@ -1127,13 +1075,13 @@
 	name = "Atmospherics Blast Door"
 	},
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "aCS" = (
@@ -1182,7 +1130,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "aEA" = (
 /obj/structure/table,
@@ -1229,8 +1177,8 @@
 /turf/open/floor/grass,
 /area/command/bridge)
 "aFk" = (
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aFp" = (
@@ -1255,6 +1203,7 @@
 	dir = 1
 	},
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "aFY" = (
@@ -1312,18 +1261,15 @@
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aGM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aGQ" = (
 /obj/structure/falsewall,
@@ -1349,13 +1295,10 @@
 /area/maintenance/fore)
 "aHx" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aHy" = (
@@ -1374,21 +1317,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"aIU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "aJc" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Robotics Lab";
@@ -1455,21 +1383,20 @@
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "aLE" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "aLS" = (
@@ -1492,36 +1419,30 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/noticeboard/directional/east,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
-"aMf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/starboard)
 "aMn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aMs" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 17
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "aMv" = (
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aMG" = (
@@ -1541,6 +1462,7 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/junglebush/c,
+/obj/structure/window,
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "aMW" = (
@@ -1595,30 +1517,30 @@
 "aNW" = (
 /turf/closed/wall,
 /area/service/lawoffice)
+"aOa" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "aOf" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/bar,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner,
-/obj/structure/disposalpipe/segment,
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "aOu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -1658,21 +1580,20 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "aPT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydroponics";
 	req_access_txt = "35"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/hydroponics)
 "aPW" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "aQc" = (
@@ -1681,16 +1602,14 @@
 /area/maintenance/department/cargo)
 "aQj" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "aQO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "aRh" = (
@@ -1727,9 +1646,9 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "aRQ" = (
-/obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
 /obj/machinery/newscaster/directional/west,
 /obj/item/holosign_creator/robot_seat/bar,
 /turf/open/floor/mineral/plastitanium{
@@ -1761,6 +1680,12 @@
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/iron/grimy,
 /area/security/prison/safe)
+"aTa" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "aTi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1768,6 +1693,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/command/teleporter)
+"aTk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "aTv" = (
 /obj/item/trash/cheesie,
 /turf/open/floor/plating,
@@ -1791,6 +1723,9 @@
 "aUz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/bluespace_vendor/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "aUA" = (
@@ -1874,31 +1809,37 @@
 /turf/open/floor/carpet/red,
 /area/service/chapel/office)
 "aVM" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "aVV" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "aWh" = (
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "aWo" = (
@@ -1926,6 +1867,12 @@
 /area/security/detectives_office)
 "aXi" = (
 /obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "aXA" = (
@@ -2034,7 +1981,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "aYY" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
@@ -2060,13 +2007,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "aZw" = (
 /turf/open/floor/iron/freezer,
@@ -2094,13 +2035,10 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bal" = (
@@ -2121,6 +2059,9 @@
 	id_tag = "MedbayFoyer";
 	name = "Medbay";
 	req_one_access_txt = "5"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -2159,6 +2100,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bbW" = (
@@ -2200,6 +2144,9 @@
 /obj/machinery/light/directional/west,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "bcV" = (
@@ -2303,14 +2250,11 @@
 /turf/open/openspace/airless,
 /area/space)
 "bfL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "bfY" = (
@@ -2324,14 +2268,11 @@
 	c_tag = "Security - Entrance";
 	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "bgk" = (
 /obj/machinery/blackbox_recorder,
@@ -2342,18 +2283,15 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "bgp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat_interior";
 	name = "Antechamber Turret Control";
 	pixel_y = -30;
 	req_access_txt = "65"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -2430,6 +2368,9 @@
 /obj/machinery/light/directional/east,
 /obj/machinery/iv_drip,
 /obj/machinery/iv_drip,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "biB" = (
@@ -2504,22 +2445,23 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "bkT" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/door_timer{
 	id = "Cell 1";
 	name = "Cell 1";
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/security/brig)
 "blh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "blx" = (
@@ -2567,15 +2509,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/security/office)
 "bmI" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -2673,6 +2611,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
+"bot" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "boG" = (
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2704,18 +2649,20 @@
 	pixel_y = 5
 	},
 /obj/machinery/bounty_board/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "boS" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/security/brig)
 "bpf" = (
 /obj/machinery/light/directional/west,
@@ -2732,12 +2679,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/security/brig)
 "bpF" = (
 /turf/closed/wall/r_wall,
@@ -2766,6 +2712,9 @@
 /area/security/office)
 "bqS" = (
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "brs" = (
@@ -2847,11 +2796,8 @@
 /area/commons/fitness/recreation)
 "buf" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/power/apc/auto_name/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "buj" = (
@@ -2863,15 +2809,14 @@
 /turf/open/floor/iron/dark,
 /area/security/prison/visit)
 "buD" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
 	},
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "buE" = (
@@ -2963,17 +2908,11 @@
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "bxv" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/south,
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bxG" = (
@@ -2985,15 +2924,14 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/security/brig)
 "bxS" = (
 /turf/closed/wall/r_wall,
@@ -3008,21 +2946,18 @@
 /area/engineering/main)
 "bxZ" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/east,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "byh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/reagent_dispensers/peppertank/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/reagent_dispensers/peppertank/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "byj" = (
 /obj/structure/table/wood,
@@ -3090,18 +3025,23 @@
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "bzI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "bzK" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "bzN" = (
@@ -3194,6 +3134,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bCi" = (
@@ -3209,6 +3150,15 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/commons/dorms)
+"bCj" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "bCl" = (
 /obj/machinery/igniter/incinerator_ordmix,
 /turf/open/floor/engine/vacuum,
@@ -3245,23 +3195,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "bCz" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bCN" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/brig)
 "bDg" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -3294,7 +3239,7 @@
 /area/science/mixing/chamber)
 "bDN" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/corner,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "bDY" = (
@@ -3337,6 +3282,9 @@
 /area/security/office)
 "bEP" = (
 /obj/machinery/bounty_board/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "bFb" = (
@@ -3366,20 +3314,17 @@
 /turf/open/floor/plating,
 /area/engineering/transit_tube)
 "bFw" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bFA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "bFI" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -3456,7 +3401,7 @@
 	dir = 1;
 	network = list("ss13","prison")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "bHU" = (
 /obj/effect/turf_decal/stripes/line,
@@ -3484,6 +3429,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/range)
+"bIf" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "bIu" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -3499,11 +3449,14 @@
 	},
 /area/science/lab)
 "bID" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "bIK" = (
@@ -3526,15 +3479,12 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "bJa" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bJh" = (
@@ -3577,6 +3527,7 @@
 	dir = 6
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "bJI" = (
@@ -3609,16 +3560,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/security/courtroom)
-"bKq" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "bKK" = (
 /obj/machinery/door/airlock/research/glass/incinerator/ordmix_interior,
 /obj/effect/mapping_helpers/airlock/locked,
@@ -3709,23 +3650,21 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "bNq" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "bNv" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "bNy" = (
@@ -3736,26 +3675,26 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "bNB" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "bNM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/office)
 "bNW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
 	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
@@ -3783,9 +3722,6 @@
 /area/command/gateway)
 "bOP" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
 	dir = 1
 	},
@@ -3830,6 +3766,9 @@
 "bPo" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "bPr" = (
@@ -3840,6 +3779,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/fore)
+"bPt" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "bPM" = (
 /obj/machinery/camera/motion{
 	c_tag = "Security - Armory External";
@@ -3888,10 +3833,7 @@
 /area/command/heads_quarters/cmo)
 "bRj" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "bRT" = (
@@ -3970,14 +3912,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "bUg" = (
@@ -3995,11 +3930,11 @@
 /turf/open/openspace/airless,
 /area/space/nearstation)
 "bVg" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bVu" = (
@@ -4059,6 +3994,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "bWZ" = (
@@ -4112,14 +4050,10 @@
 /area/maintenance/disposal/incinerator)
 "bYM" = (
 /obj/machinery/telecomms/server/presets/command,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/trimline/blue/filled/end{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "bZd" = (
@@ -4137,6 +4071,9 @@
 	name = "Cargo Bay RC";
 	pixel_y = 30
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "bZp" = (
@@ -4147,6 +4084,9 @@
 	normaldoorcontrol = 1;
 	pixel_x = -26;
 	req_access_txt = "5"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -4165,13 +4105,9 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "bZU" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "bZZ" = (
@@ -4187,6 +4123,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"caw" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "caG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -4207,24 +4150,14 @@
 	name = "bridge blast door"
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
-"cbi" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/science/research)
 "cbP" = (
 /obj/item/trash/candy{
 	pixel_y = 8
@@ -4241,18 +4174,8 @@
 /turf/open/floor/iron/sepia,
 /area/service/chapel)
 "cbZ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/port)
+/turf/open/floor/iron/dark/smooth_large,
+/area/security/brig)
 "cca" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/cardboard,
@@ -4305,13 +4228,13 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "cdP" = (
+/obj/effect/landmark/start/assistant,
 /obj/machinery/camera{
 	c_tag = "Aft Hallway - Ian's Room"
 	},
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "cdX" = (
@@ -4408,14 +4331,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "cgr" = (
@@ -4447,11 +4363,13 @@
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "cgB" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "cgQ" = (
@@ -4470,12 +4388,16 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"chv" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "chy" = (
 /obj/structure/chair/sofa/corner{
 	name = "plush sofa"
@@ -4505,6 +4427,7 @@
 "chN" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "chV" = (
@@ -4580,6 +4503,13 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/science/misc_lab)
+"ckH" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "ckT" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4595,34 +4525,12 @@
 "clG" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
-"clI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "clJ" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cmj" = (
@@ -4637,6 +4545,14 @@
 /obj/structure/altar_of_gods,
 /turf/open/floor/carpet/red,
 /area/service/chapel)
+"cnf" = (
+/obj/structure/cable,
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "cnY" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -4677,7 +4593,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "coS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4708,6 +4624,9 @@
 /area/command/heads_quarters/hop)
 "cpL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "cpO" = (
@@ -4730,7 +4649,7 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "cqj" = (
 /obj/machinery/light,
@@ -4797,9 +4716,6 @@
 /obj/machinery/door/poddoor,
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
-"csg" = (
-/turf/open/floor/iron,
-/area/security/brig)
 "cso" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -4808,28 +4724,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "csx" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "csA" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/bluespace_vendor/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -5073,14 +4974,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
 	req_access_txt = "31"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "cwo" = (
@@ -5094,14 +4995,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "cwv" = (
@@ -5166,18 +5064,14 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "cxG" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -5197,10 +5091,7 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "cxV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -5251,6 +5142,9 @@
 /obj/item/crowbar,
 /obj/item/assembly/flash,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "cyw" = (
@@ -5258,13 +5152,16 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "cyC" = (
+/obj/effect/landmark/start/hangover,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/landmark/start/hangover,
 /obj/structure/chair/stool/bar{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
@@ -5317,23 +5214,26 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"czs" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "czv" = (
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "czA" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -5365,15 +5265,14 @@
 /turf/open/floor/iron/dark,
 /area/science/lab)
 "cCa" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/machinery/computer/crew{
 	dir = 1
 	},
 /obj/machinery/light/directional/south,
 /obj/machinery/bounty_board/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "cCx" = (
@@ -5423,10 +5322,7 @@
 /turf/open/floor/iron/white,
 /area/science/research)
 "cDx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -5512,6 +5408,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"cFv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
+/area/security/brig)
 "cFz" = (
 /obj/machinery/ore_silo,
 /obj/effect/turf_decal/bot,
@@ -5561,13 +5468,13 @@
 /turf/open/floor/iron,
 /area/engineering/main)
 "cGA" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/table,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen";
 	name = "Serving Hatch"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/spawner/lootdrop/refreshing_beverage,
 /turf/open/floor/iron,
 /area/service/kitchen)
@@ -5615,21 +5522,18 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
-"cHI" = (
-/turf/open/floor/engine/vacuum,
-/area/science/mixing/chamber)
-"cHR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/chair{
+"cHz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"cHI" = (
+/turf/open/floor/engine/vacuum,
+/area/science/mixing/chamber)
 "cHU" = (
 /obj/effect/decal/cleanable/food/plant_smudge,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5684,12 +5588,6 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/command)
 "cJK" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
@@ -5797,11 +5695,19 @@
 /obj/structure/window,
 /turf/open/floor/iron,
 /area/security/courtroom)
-"cNa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"cMs" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
+/area/hallway/primary/starboard)
+"cNa" = (
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 8
+	},
 /area/security/brig)
 "cNi" = (
 /obj/effect/turf_decal/stripes/line{
@@ -5836,8 +5742,7 @@
 "cNH" = (
 /obj/structure/closet/secure_closet/courtroom,
 /obj/item/gavelhammer,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -5850,15 +5755,12 @@
 /area/maintenance/fore)
 "cOn" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cOD" = (
@@ -5889,6 +5791,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/security/armory)
+"cPk" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "cPM" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -5917,11 +5825,8 @@
 /area/maintenance/department/cargo)
 "cRy" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "cRC" = (
@@ -6023,6 +5928,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "cUa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -6031,10 +5939,7 @@
 	name = "Custodial Closet";
 	req_access_txt = "26"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "cUe" = (
@@ -6107,14 +6012,11 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cVB" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/computer/rdconsole{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/end,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "cVK" = (
@@ -6128,13 +6030,18 @@
 "cVV" = (
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
+"cWb" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "cWe" = (
-/obj/machinery/light/small/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/security/brig)
 "cWu" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -6152,6 +6059,7 @@
 "cWF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "cWR" = (
@@ -6173,9 +6081,9 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "cXC" = (
-/obj/structure/grille,
-/turf/open/openspace/airless,
-/area/space/nearstation)
+/obj/item/radio/intercom/directional/west,
+/turf/open/floor/iron,
+/area/hallway/secondary/entry)
 "cXE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6231,19 +6139,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "cYJ" = (
@@ -6263,13 +6165,12 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cZl" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "cZv" = (
@@ -6279,6 +6180,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -6287,6 +6191,9 @@
 "cZw" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "cZI" = (
@@ -6340,21 +6247,15 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "dbk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -6375,6 +6276,9 @@
 /area/service/hydroponics/garden)
 "dbK" = (
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dbL" = (
@@ -6386,16 +6290,16 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "dbP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "dbS" = (
@@ -6415,15 +6319,11 @@
 /turf/open/floor/grass,
 /area/medical/medbay/lobby)
 "dbT" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "dcA" = (
@@ -6432,6 +6332,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"dcK" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "dcN" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom";
@@ -6461,6 +6367,9 @@
 /obj/item/cartridge/quartermaster,
 /obj/item/cartridge/quartermaster,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/cargo/qm)
 "ddg" = (
@@ -6475,13 +6384,13 @@
 /area/service/hydroponics/garden)
 "ddB" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ddC" = (
@@ -6492,11 +6401,11 @@
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "ddR" = (
-/obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/structure/chair/stool/bar,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "ddY" = (
@@ -6520,12 +6429,15 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
 "deu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	name = "chemistry sorting disposal pipe";
+	sortType = 11
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "dew" = (
@@ -6533,6 +6445,9 @@
 /area/maintenance/department/medical)
 "deD" = (
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "deK" = (
@@ -6572,13 +6487,6 @@
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
 "dga" = (
-/obj/machinery/door/airlock/virology{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "Virology_Airlock_Interior";
-	name = "Virology Interior Airlock";
-	req_access_txt = "39"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -6601,11 +6509,12 @@
 	},
 /obj/structure/cable,
 /obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
+/obj/machinery/door/airlock/virology{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "Virology_Airlock_Interior";
+	name = "Virology Interior Airlock";
+	req_access_txt = "39"
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
@@ -6621,14 +6530,14 @@
 "dgO" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "dgR" = (
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "dgU" = (
@@ -6637,17 +6546,13 @@
 /obj/item/clothing/suit/apron/surgical,
 /obj/item/clothing/mask/surgical,
 /obj/item/razor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera{
 	c_tag = "Medbay - Surgery";
 	dir = 1;
 	network = list("ss13","medbay")
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -6672,12 +6577,18 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
+"dhf" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "dhh" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass{
 	name = "Kitchen Hydroponics Access";
 	req_access_txt = "28"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/service/hydroponics)
@@ -6718,22 +6629,17 @@
 /turf/open/floor/plating,
 /area/medical/break_room)
 "dio" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "diB" = (
@@ -6744,12 +6650,11 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "diC" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/effect/landmark/start/geneticist,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "diG" = (
@@ -6801,8 +6706,20 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
+"dja" = (
+/obj/structure/chair/office/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "djg" = (
 /obj/structure/cable,
 /turf/open/floor/plating{
@@ -6888,14 +6805,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "dlq" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "dlv" = (
@@ -6936,6 +6849,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "dmF" = (
@@ -6961,23 +6877,11 @@
 /area/maintenance/department/engine/atmos)
 "dnx" = (
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
-"dnG" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	name = "dorms sorting disposal pipe";
-	sortType = 26
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/hallway/primary/fore)
 "dnN" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -6989,6 +6893,9 @@
 "dnX" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "doc" = (
@@ -7082,25 +6989,22 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "dqL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/north,
 /obj/machinery/light/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "dqT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "dro" = (
 /obj/machinery/airalarm/directional/west,
@@ -7127,19 +7031,13 @@
 	name = "kitchen sorting disposal pipe";
 	sortType = 20
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "drM" = (
@@ -7188,15 +7086,15 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "dsT" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Aft Hallway - HoP Line";
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/noticeboard/directional/east,
+/obj/effect/turf_decal/loading_area{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "dsY" = (
@@ -7243,15 +7141,16 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/directional/east,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/bounty_board/directional/east,
 /obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "dtV" = (
 /obj/structure/chair/comfy/beige{
@@ -7313,8 +7212,8 @@
 /area/engineering/lobby)
 "dvU" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "dvZ" = (
@@ -7326,6 +7225,9 @@
 /area/security/prison)
 "dwj" = (
 /obj/machinery/rnd/production/techfab/department/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "dwk" = (
@@ -7372,15 +7274,12 @@
 "dxQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "dxT" = (
 /obj/structure/window/reinforced{
@@ -7390,7 +7289,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "dya" = (
 /obj/structure/sign/warning/radiation,
@@ -7424,17 +7323,14 @@
 	pixel_x = -10;
 	pixel_y = 22
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "dys" = (
 /obj/machinery/computer/security/telescreen/prison{
 	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/camera{
@@ -7443,7 +7339,10 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "dyE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7460,7 +7359,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "dyM" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -7513,6 +7412,7 @@
 /turf/open/floor/grass,
 /area/security/courtroom)
 "dzG" = (
+/obj/effect/landmark/start/depsec/supply,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = -22
@@ -7520,7 +7420,9 @@
 /obj/machinery/bounty_board/directional/south{
 	pixel_x = 3
 	},
-/obj/effect/landmark/start/depsec/supply,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "dzJ" = (
@@ -7597,14 +7499,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "dBG" = (
@@ -7616,14 +7515,11 @@
 /area/security/office)
 "dCa" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "dCh" = (
@@ -7775,13 +7671,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "dGu" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "dGG" = (
@@ -7815,14 +7705,16 @@
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/flora/junglebush/b,
 /obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/window{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "dHg" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/spawner/randomcolavend,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/spawner/randomcolavend,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "dHi" = (
@@ -7832,7 +7724,7 @@
 	req_access_txt = "1"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "dHl" = (
 /obj/structure/table,
@@ -7858,6 +7750,9 @@
 /area/hallway/secondary/service)
 "dIF" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "dIK" = (
@@ -7866,8 +7761,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/blobstart,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
+"dIN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
 "dIY" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/barricade/wooden,
@@ -7886,6 +7793,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"dJv" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "dJz" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -7894,14 +7810,17 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "dJJ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/end{
+	dir = 1
+	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
 	name = "Brig";
 	req_access_txt = "63"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "dJS" = (
 /obj/item/kirbyplants/random,
@@ -7951,6 +7870,9 @@
 "dLc" = (
 /obj/machinery/light/directional/north,
 /obj/structure/noticeboard/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "dLh" = (
@@ -8010,23 +7932,19 @@
 /area/hallway/secondary/command)
 "dNg" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "dNh" = (
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "dNu" = (
 /obj/machinery/light/directional/east,
@@ -8052,11 +7970,8 @@
 /turf/open/floor/wood/large,
 /area/service/library)
 "dNB" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
@@ -8128,6 +8043,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/corner,
 /turf/open/floor/iron/white,
 /area/science/research)
 "dQk" = (
@@ -8168,8 +8084,8 @@
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "dRe" = (
-/obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/south,
 /turf/open/floor/wood,
 /area/service/library)
 "dRg" = (
@@ -8251,14 +8167,11 @@
 /turf/open/floor/iron,
 /area/engineering/storage)
 "dTl" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "dTu" = (
@@ -8305,20 +8218,16 @@
 	},
 /turf/open/floor/grass,
 /area/service/library)
+"dTS" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "dUl" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engineering/main)
-"dUE" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
 "dUP" = (
 /turf/open/floor/iron/smooth_half,
 /area/engineering/gravity_generator)
@@ -8361,17 +8270,8 @@
 /area/hallway/secondary/command)
 "dWL" = (
 /obj/machinery/porta_turret/ai,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/status_display/evac/directional/east,
+/obj/effect/turf_decal/tile/neutral/full,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "dWR" = (
@@ -8379,18 +8279,14 @@
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "dWX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/aft)
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/security/brig)
 "dWZ" = (
 /turf/closed/wall/r_wall,
 /area/science/genetics)
@@ -8404,6 +8300,7 @@
 "dXk" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "dXK" = (
@@ -8540,13 +8437,14 @@
 	sortType = 8
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "ebO" = (
 /obj/effect/turf_decal/stripes/line,
@@ -8554,6 +8452,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit/departure_lounge)
+"ebQ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "ebR" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
@@ -8591,14 +8495,11 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "edz" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/effect/turf_decal/siding/purple/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "edD" = (
@@ -8741,8 +8642,8 @@
 /turf/open/floor/iron,
 /area/ai_monitored/command/storage/eva)
 "ehP" = (
-/obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/machinery/light/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "ehS" = (
@@ -8795,6 +8696,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 1
 	},
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating/airless,
 /area/maintenance/disposal/incinerator)
 "ejK" = (
@@ -8806,6 +8708,7 @@
 /area/engineering/atmos)
 "ejQ" = (
 /obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "ekg" = (
@@ -8841,8 +8744,7 @@
 	pixel_x = 22;
 	pixel_y = 11
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -8987,16 +8889,6 @@
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
 /turf/open/floor/iron,
 /area/commons/dorms)
-"enK" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/landmark/start/hangover,
-/turf/open/floor/iron,
-/area/hallway/primary/port)
 "eoq" = (
 /turf/open/floor/iron/dark,
 /area/security/office)
@@ -9009,6 +8901,15 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
+"epN" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "epS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9063,6 +8964,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "era" = (
@@ -9097,6 +9001,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"ery" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4;
+	name = "dorms sorting disposal pipe";
+	sortType = 26
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "erM" = (
 /obj/structure/cable,
 /obj/structure/table,
@@ -9139,9 +9055,8 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
@@ -9165,11 +9080,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "esM" = (
 /obj/structure/extinguisher_cabinet/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -9333,7 +9254,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "exg" = (
 /obj/structure/lattice,
@@ -9356,10 +9277,9 @@
 /area/science/xenobiology)
 "exv" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "exH" = (
@@ -9496,15 +9416,11 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "ezV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -9569,17 +9485,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "eBC" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "eCr" = (
@@ -9622,14 +9533,11 @@
 /turf/closed/wall/r_wall,
 /area/security/range)
 "eDE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "eDH" = (
 /obj/machinery/door/airlock/command/glass{
@@ -9651,9 +9559,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "eDP" = (
-/obj/machinery/status_display/evac{
-	pixel_y = -32
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "eDR" = (
@@ -9685,11 +9594,11 @@
 	},
 /area/security/courtroom)
 "eEs" = (
+/obj/effect/landmark/start/hangover,
 /obj/structure/chair/sofa{
 	dir = 8;
 	name = "plush sofa"
 	},
-/obj/effect/landmark/start/hangover,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /obj/machinery/light/warm/directional/east,
 /turf/open/floor/wood,
@@ -9716,25 +9625,19 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "eFf" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "eFh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "eFy" = (
@@ -9823,7 +9726,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "eGO" = (
 /turf/open/floor/iron,
@@ -9836,14 +9739,19 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"eHe" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/command/storage/eva)
 "eHh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "eHj" = (
@@ -9872,6 +9780,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "eHU" = (
@@ -9892,8 +9803,17 @@
 "eIb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"eId" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "eIo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -9907,15 +9827,12 @@
 /area/engineering/transit_tube)
 "eIx" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "eIz" = (
@@ -9930,6 +9847,9 @@
 	dir = 8;
 	network = list("ss13","rd")
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "eIK" = (
@@ -9938,6 +9858,9 @@
 /area/security/execution/transfer)
 "eIN" = (
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "eIV" = (
@@ -9947,15 +9870,11 @@
 /turf/open/floor/plating,
 /area/engineering/atmos/control_center)
 "eJc" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -10054,28 +9973,16 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "eKN" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "eKO" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
-"eKU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig)
 "eKW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -10095,10 +10002,10 @@
 "eLs" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
 	},
-/turf/open/floor/iron/dark/side,
+/turf/open/floor/iron/dark,
 /area/command/bridge)
 "eLu" = (
 /obj/structure/window{
@@ -10183,6 +10090,7 @@
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "eNg" = (
@@ -10362,6 +10270,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "eRT" = (
@@ -10381,11 +10292,10 @@
 "eRX" = (
 /obj/effect/landmark/start/warden,
 /obj/structure/chair/office,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "eSs" = (
@@ -10568,6 +10478,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "eWE" = (
@@ -10608,6 +10521,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/department/engine/atmos)
 "eXd" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -10626,7 +10540,6 @@
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/storage/bag/trash,
 /obj/item/storage/bag/trash,
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
@@ -10744,7 +10657,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "fbg" = (
 /obj/machinery/vending/cigarette,
@@ -10760,8 +10673,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "fbR" = (
-/obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "fca" = (
@@ -10771,6 +10684,9 @@
 "fcf" = (
 /obj/machinery/computer/cargo{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
@@ -10803,6 +10719,9 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fcD" = (
@@ -10825,18 +10744,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"fcT" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "fcX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -10850,7 +10757,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "fdN" = (
 /obj/machinery/suit_storage_unit/atmos,
@@ -10898,6 +10805,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fex" = (
@@ -10947,7 +10857,7 @@
 "feT" = (
 /obj/structure/table,
 /obj/machinery/newscaster/directional/south,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "feW" = (
 /obj/machinery/computer/atmos_control{
@@ -11075,12 +10985,12 @@
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
 "fhZ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance{
 	name = "service maintenance";
 	req_one_access_txt = "12;22;25;26;28;35;37;38;46"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "fif" = (
@@ -11123,11 +11033,10 @@
 "fix" = (
 /obj/structure/table/optable,
 /obj/item/surgical_drapes,
-/obj/effect/turf_decal/tile/blue{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "fiA" = (
@@ -11212,6 +11121,9 @@
 /area/commons/dorms)
 "fki" = (
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fkq" = (
@@ -11228,8 +11140,8 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "fkC" = (
-/obj/machinery/griddle,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/griddle,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "fkN" = (
@@ -11256,14 +11168,10 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "flB" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/spawner/randomcolavend,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/spawner/randomcolavend,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "flJ" = (
@@ -11351,6 +11259,9 @@
 /obj/machinery/status_display/supply{
 	pixel_y = -30
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "fnr" = (
@@ -11375,6 +11286,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "fom" = (
@@ -11476,7 +11391,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "frc" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
@@ -11547,10 +11462,10 @@
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fsA" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
 "fsD" = (
@@ -11604,12 +11519,6 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "fsY" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/requests_console{
 	department = "Genetics";
 	name = "Genetics Requests Console";
@@ -11617,6 +11526,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "ftb" = (
@@ -11692,6 +11604,7 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/research)
 "fua" = (
@@ -11753,6 +11666,9 @@
 "fvb" = (
 /obj/machinery/atmospherics/components/binary/thermomachine/freezer,
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "fve" = (
@@ -11904,15 +11820,18 @@
 /turf/open/openspace,
 /area/science/xenobiology)
 "fzT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "fAf" = (
@@ -12029,10 +11948,7 @@
 "fCK" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "fDo" = (
@@ -12060,15 +11976,9 @@
 	c_tag = "Central Hallway - Hydroponics";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -12089,8 +11999,8 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "fEC" = (
-/obj/structure/table/wood,
 /obj/effect/landmark/start/hangover,
+/obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/service/bar)
 "fEN" = (
@@ -12134,19 +12044,18 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "fFn" = (
 /obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/control_center)
 "fFq" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/modular_computer/console/preset/command{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -12204,17 +12113,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai)
-"fGO" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
 "fGS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
 /obj/effect/turf_decal/tile/yellow{
@@ -12232,14 +12130,11 @@
 /turf/open/openspace,
 /area/science/xenobiology)
 "fHp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "fHE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
@@ -12292,6 +12187,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "fIW" = (
@@ -12315,18 +12213,21 @@
 	},
 /obj/machinery/newscaster/directional/south,
 /obj/effect/landmark/start/scientist,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "fJI" = (
-/obj/machinery/door/airlock/glass{
-	name = "Bar";
-	req_access_txt = "25"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/glass{
+	name = "Bar";
+	req_access_txt = "25"
+	},
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
@@ -12384,17 +12285,10 @@
 /turf/closed/wall/r_wall,
 /area/command/bridge)
 "fKG" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/closet/secure_closet/medical2,
 /obj/item/book/manual/wiki/surgery,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
@@ -12410,30 +12304,23 @@
 /area/maintenance/solars/starboard/aft)
 "fKT" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fKZ" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "fLi" = (
 /obj/structure/table/wood,
@@ -12448,6 +12335,10 @@
 /obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"fLD" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "fMj" = (
 /obj/effect/spawner/lootdrop/gross_decal_spawner,
 /obj/effect/spawner/lootdrop/maint_drugs,
@@ -12503,13 +12394,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
 "fNr" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "fNI" = (
@@ -12557,19 +12445,14 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "fOC" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "fPa" = (
@@ -12624,15 +12507,11 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "fPY" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "fQi" = (
@@ -12668,11 +12547,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/atmos/control_center)
 "fRo" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -12680,7 +12554,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/end{
+	dir = 1
+	},
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "fRq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12761,14 +12643,10 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "fTf" = (
@@ -12780,6 +12658,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"fTo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "fTy" = (
 /obj/structure/table,
 /obj/item/disk/tech_disk{
@@ -12823,19 +12708,13 @@
 /obj/structure/chair/office/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "fVg" = (
@@ -12855,13 +12734,13 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/rd)
 "fVp" = (
+/obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
-/obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "fVL" = (
@@ -12883,6 +12762,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "fWk" = (
@@ -12965,10 +12847,10 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "fXv" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "fXJ" = (
@@ -13060,6 +12942,9 @@
 "fZB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "fZC" = (
@@ -13114,17 +12999,10 @@
 /turf/open/floor/plating,
 /area/medical/pharmacy)
 "gbQ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "gbY" = (
@@ -13133,15 +13011,12 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "gcs" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "gcI" = (
@@ -13162,6 +13037,7 @@
 /area/maintenance/central/secondary)
 "gdu" = (
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "gdw" = (
@@ -13200,6 +13076,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gef" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "ges" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -13217,6 +13101,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/research)
 "geN" = (
@@ -13240,16 +13125,22 @@
 /obj/structure/window{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
 /obj/structure/flora/junglebush/b,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "ggc" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/grass,
 /area/science/genetics)
+"ggm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/cargo/office)
 "ggN" = (
 /obj/machinery/light/directional/north,
 /obj/structure/table/reinforced,
@@ -13286,6 +13177,9 @@
 	name = "Patient's Belongings"
 	},
 /obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "ghL" = (
@@ -13341,14 +13235,14 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "gjw" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "gjz" = (
@@ -13416,19 +13310,16 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "gkF" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
+	dir = 4
 	},
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/visible{
-	dir = 4
-	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gkI" = (
@@ -13456,20 +13347,17 @@
 /turf/open/floor/grass,
 /area/hallway/primary/central)
 "gld" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "gle" = (
 /obj/structure/table,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "glq" = (
@@ -13480,13 +13368,14 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "gls" = (
+/obj/effect/landmark/start/hangover,
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/light/directional/west,
 /obj/structure/table,
-/obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "glx" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hopqueue";
 	name = "HoP Queue Shutters"
@@ -13494,49 +13383,50 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "glz" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/science/xenobiology)
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "glB" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "glO" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "glR" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "glU" = (
-/obj/machinery/light/directional/west,
 /obj/structure/cable,
+/obj/machinery/light/directional/west,
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
@@ -13591,6 +13481,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"gnr" = (
+/obj/structure/bed,
+/obj/item/bedsheet/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "gnv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13616,11 +13514,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "gop" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "gor" = (
@@ -13628,6 +13526,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"gou" = (
+/obj/effect/spawner/randomsnackvend,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "goI" = (
 /obj/machinery/light/small/red/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13646,13 +13551,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "gpk" = (
 /obj/structure/closet/crate,
@@ -13664,6 +13565,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "gpq" = (
@@ -13680,15 +13582,12 @@
 	},
 /area/command/heads_quarters/ce)
 "gpN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/warning{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "gqe" = (
@@ -13758,11 +13657,8 @@
 /turf/open/floor/iron/dark/smooth_half,
 /area/command/bridge)
 "grb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "grw" = (
@@ -13822,6 +13718,7 @@
 	},
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/toxin,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "gsX" = (
@@ -13862,6 +13759,9 @@
 /area/engineering/atmos)
 "gur" = (
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "gus" = (
@@ -13881,7 +13781,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "gve" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13939,12 +13839,9 @@
 	dir = 8
 	},
 /obj/structure/window,
-/obj/machinery/status_display/evac{
-	layer = 4;
-	pixel_y = 32
-	},
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "gwq" = (
@@ -14002,10 +13899,10 @@
 	},
 /area/maintenance/port)
 "gxN" = (
+/obj/structure/cable,
 /obj/structure/table/wood,
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/power/apc/auto_name/south,
-/obj/structure/cable,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
@@ -14039,6 +13936,9 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "gym" = (
@@ -14101,6 +14001,13 @@
 	},
 /turf/open/floor/wood,
 /area/service/bar)
+"gzF" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "gzN" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14209,18 +14116,17 @@
 "gBS" = (
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "gBT" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/primary/port)
 "gCa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
@@ -14234,7 +14140,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "gCm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14344,14 +14250,10 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "gES" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/trimline/blue/filled/end{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "gFe" = (
@@ -14373,8 +14275,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "gGC" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -14438,6 +14339,9 @@
 "gHW" = (
 /obj/structure/disposalpipe/segment,
 /obj/vehicle/sealed/mecha/working/ripley/cargo,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/cargo/storage)
 "gHZ" = (
@@ -14479,8 +14383,7 @@
 "gIS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -14512,6 +14415,15 @@
 /obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/rd)
+"gJC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "gJG" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
@@ -14522,12 +14434,11 @@
 /turf/open/floor/iron/sepia,
 /area/service/chapel)
 "gJK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/status_display/evac/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/security/brig)
 "gJN" = (
 /obj/structure/closet/crate,
@@ -14597,17 +14508,11 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "gKX" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -14617,6 +14522,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "gLc" = (
@@ -14671,10 +14579,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "gMD" = (
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/iron,
 /area/cargo/office)
 "gMJ" = (
@@ -14708,6 +14616,9 @@
 /obj/machinery/status_display/supply{
 	pixel_y = -30
 	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "gNZ" = (
@@ -14715,17 +14626,14 @@
 /turf/open/floor/carpet/green,
 /area/service/library)
 "gOg" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/status_display/evac/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "gOj" = (
@@ -14780,23 +14688,17 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "gPz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "gPA" = (
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "gPI" = (
 /obj/structure/disposalpipe/segment{
@@ -14889,19 +14791,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
-"gQO" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "gQP" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -14981,9 +14870,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "gSF" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -14996,10 +14884,7 @@
 	},
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "gSU" = (
@@ -15091,12 +14976,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "gUA" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -15107,12 +14986,12 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "gUG" = (
+/obj/structure/cable,
+/obj/machinery/duct,
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Storage Maintenance";
 	req_access_txt = "25"
 	},
-/obj/structure/cable,
-/obj/machinery/duct,
 /obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
@@ -15150,12 +15029,13 @@
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "gVG" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "gVH" = (
 /obj/machinery/light/directional/east,
@@ -15185,15 +15065,14 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "gVU" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/hallway/primary/port)
 "gVY" = (
 /obj/machinery/button/door{
 	id = "visitation";
@@ -15219,13 +15098,13 @@
 	},
 /area/maintenance/department/cargo)
 "gWh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Hydroponics Maintenance";
 	req_access_txt = "35"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -15304,8 +15183,8 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "gXn" = (
-/obj/structure/chair/wood,
 /obj/effect/landmark/start/assistant,
+/obj/structure/chair/wood,
 /turf/open/floor/wood,
 /area/service/bar)
 "gXq" = (
@@ -15317,6 +15196,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
@@ -15350,8 +15235,8 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "gXJ" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/newscaster/directional/west,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "gYj" = (
@@ -15373,6 +15258,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "gYt" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
@@ -15399,19 +15287,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"haf" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "hau" = (
 /obj/structure/window{
 	dir = 4
@@ -15426,6 +15301,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "haD" = (
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/east,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -15437,7 +15313,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/theater)
 "haT" = (
@@ -15483,16 +15358,10 @@
 /turf/closed/wall,
 /area/maintenance/central)
 "hci" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "hcm" = (
@@ -15503,6 +15372,10 @@
 /area/maintenance/starboard/fore)
 "hco" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "hcG" = (
@@ -15524,13 +15397,13 @@
 /turf/open/floor/iron/sepia,
 /area/service/chapel)
 "hdm" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/table,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen";
 	name = "Serving Hatch"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "hdp" = (
@@ -15570,22 +15443,15 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "hek" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/noticeboard/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "hen" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -15594,6 +15460,13 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hew" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "hez" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -15629,11 +15502,13 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "hfd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "hfk" = (
@@ -15655,6 +15530,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/command/heads_quarters/captain/private)
+"hfP" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/cargo/office)
 "hfW" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -15663,6 +15544,12 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"hga" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "hgd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -15708,6 +15595,15 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron/dark/textured_large,
 /area/command/heads_quarters/captain)
+"hht" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "hhv" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Pure Chamber";
@@ -15777,6 +15673,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
+"hiZ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "hjh" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -15798,9 +15700,6 @@
 /area/engineering/atmos)
 "hkp" = (
 /obj/machinery/atmospherics/pipe/smart/simple/brown/visible,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
@@ -15833,6 +15732,18 @@
 /obj/effect/loot_site_spawner,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hkT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "hlh" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/flashlight/lantern{
@@ -15845,6 +15756,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "hlD" = (
@@ -15895,18 +15812,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hmC" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/item/beacon,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
-/obj/item/beacon,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "hmH" = (
@@ -16001,14 +15913,7 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hpF" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "hpV" = (
@@ -16070,13 +15975,13 @@
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "hrM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/structure/cable,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	desc = "The chefs most 'trusted' pet Goat. Just don't stare at him too long.";
 	name = "Pete"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/duct,
-/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
 "hsq" = (
@@ -16094,9 +15999,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "hsD" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
@@ -16169,21 +16071,17 @@
 /turf/open/floor/wood,
 /area/service/library)
 "htM" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "htX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "hvl" = (
 /obj/machinery/light_switch{
@@ -16204,6 +16102,9 @@
 /obj/machinery/camera{
 	c_tag = "Science - Hallway";
 	network = list("ss13","rd")
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -16318,13 +16219,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/command/heads_quarters/hos)
-"hxj" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "hxo" = (
 /obj/structure/cable,
 /obj/machinery/requests_console{
@@ -16334,6 +16228,9 @@
 	pixel_y = -30
 	},
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "hxx" = (
@@ -16345,12 +16242,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hxY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Prison Wing";
 	req_access_txt = "2"
@@ -16359,7 +16250,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "hxZ" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -16369,6 +16263,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "hyb" = (
@@ -16377,13 +16274,6 @@
 	dir = 4;
 	network = list("minisat")
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/table,
 /obj/item/multitool{
 	pixel_x = 7;
@@ -16391,6 +16281,9 @@
 	},
 /obj/item/radio/off{
 	pixel_x = -4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -16448,13 +16341,10 @@
 "hAb" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "hAu" = (
 /obj/machinery/power/solar_control{
@@ -16477,14 +16367,8 @@
 /area/science/mixing/chamber)
 "hAN" = (
 /obj/machinery/telecomms/server/presets/supply,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/end{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
@@ -16550,6 +16434,9 @@
 "hCg" = (
 /obj/structure/sign/poster/random{
 	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
@@ -16639,11 +16526,11 @@
 /turf/open/openspace,
 /area/science/xenobiology)
 "hEJ" = (
-/obj/effect/turf_decal/delivery,
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "hEL" = (
@@ -16674,6 +16561,16 @@
 	},
 /turf/open/floor/wood,
 /area/commons/dorms)
+"hFJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "hHk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer2{
 	dir = 1
@@ -16690,6 +16587,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "hIc" = (
@@ -16844,6 +16744,7 @@
 "hKB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "hKI" = (
@@ -17010,19 +16911,6 @@
 "hOp" = (
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"hOC" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "hOW" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor/heavy,
@@ -17201,13 +17089,13 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "hTJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Dock";
 	req_access_txt = "48"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
@@ -17300,10 +17188,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "hWv" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "hWw" = (
@@ -17333,10 +17218,7 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "hWG" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/brown/filled/warning,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "hWK" = (
@@ -17382,6 +17264,9 @@
 "hXj" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/bounty_board/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "hXl" = (
@@ -17447,13 +17332,7 @@
 /obj/structure/sign/departments/cargo{
 	pixel_y = -30
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "hZN" = (
@@ -17482,15 +17361,18 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "iak" = (
 /turf/closed/wall,
 /area/maintenance/aft)
 "iam" = (
+/obj/structure/cable,
 /obj/machinery/light/directional/west,
 /obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -17510,10 +17392,8 @@
 /area/maintenance/central)
 "iaV" = (
 /obj/structure/table,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
 /obj/item/book/manual/wiki/robotics_cyborgs,
+/obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron/dark,
 /area/science/robotics/lab)
 "iaY" = (
@@ -17538,12 +17418,12 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "ibn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/bar)
 "ibE" = (
@@ -17615,7 +17495,9 @@
 /area/medical/treatment_center)
 "icz" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "icF" = (
@@ -17645,9 +17527,18 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics)
+"idh" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "idj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -17680,6 +17571,9 @@
 /obj/item/clothing/gloves/cargo_gauntlet{
 	pixel_y = 3
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "idP" = (
@@ -17687,16 +17581,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "idX" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ieb" = (
@@ -17706,15 +17594,21 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iec" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
+"iek" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "ieo" = (
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/iron,
@@ -17907,6 +17801,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"iiL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "iiO" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -17937,19 +17839,22 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"ijJ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+"ijG" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
+/turf/open/floor/iron,
+/area/hallway/primary/aft)
+"ijJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -17958,6 +17863,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
 /obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "ijM" = (
@@ -17975,6 +17886,15 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"iki" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "ikr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
@@ -17985,13 +17905,10 @@
 /area/science/storage)
 "ikt" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ikC" = (
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
@@ -18006,6 +17923,7 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ilb" = (
@@ -18034,19 +17952,23 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/atmos/experiment_room)
-"inb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+"imE" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/warning/securearea{
-	pixel_x = 32
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
 	},
+/turf/open/floor/iron/white,
+/area/science/research)
+"inb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/structure/sign/warning/securearea{
+	pixel_x = 32
+	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -18119,13 +18041,11 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/airless,
 /area/science/test_area)
+"ioF" = (
+/obj/machinery/status_display/evac/directional/east,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "ioU" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -18135,6 +18055,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "ioW" = (
@@ -18165,6 +18088,9 @@
 "ipu" = (
 /obj/structure/closet/l3closet,
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "ipC" = (
@@ -18314,6 +18240,9 @@
 	name = "AI Upload turret control";
 	pixel_y = 25
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ite" = (
@@ -18326,8 +18255,20 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
+"its" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "itA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18382,6 +18323,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "iuB" = (
@@ -18494,6 +18438,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"ixl" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "ixx" = (
 /obj/structure/chair{
 	dir = 4
@@ -18535,7 +18488,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/courtroom)
 "iyH" = (
 /obj/machinery/computer/secure_data{
@@ -18561,6 +18514,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/maintenance/fore)
+"izz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "izM" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -18591,25 +18553,22 @@
 /turf/open/floor/grass,
 /area/security/detectives_office/bridge_officer_office)
 "iAc" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/reagent_dispensers/plumbed{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
 	},
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/light/cold/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white/textured,
 /area/medical/cryo)
 "iAD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "iAW" = (
@@ -18668,17 +18627,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "iCv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "iCH" = (
 /obj/structure/closet/emcloset/anchored,
@@ -18753,6 +18708,9 @@
 /obj/machinery/computer/med_data{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "iEd" = (
@@ -18770,6 +18728,9 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "iEp" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "iEM" = (
@@ -18869,9 +18830,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "iHJ" = (
+/obj/structure/disposalpipe/trunk,
 /obj/item/radio/intercom/directional/east,
 /obj/machinery/light_switch{
 	pixel_x = 22;
@@ -18884,7 +18849,6 @@
 	pixel_y = -8
 	},
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -18938,9 +18902,11 @@
 /turf/closed/wall/r_wall,
 /area/science/research)
 "iIR" = (
-/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -18956,6 +18922,9 @@
 "iJL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "iKd" = (
@@ -18972,6 +18941,8 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "iKp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
 /obj/item/reagent_containers/food/condiment/enzyme{
 	layer = 5;
@@ -18980,8 +18951,6 @@
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "iKr" = (
@@ -19023,10 +18992,7 @@
 	dir = 8;
 	pixel_y = -28
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "iLU" = (
@@ -19036,20 +19002,20 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "iLW" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "iMb" = (
 /obj/machinery/computer/communications{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -19123,11 +19089,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/security/detectives_office/bridge_officer_office)
 "iNV" = (
-/obj/structure/sign/departments/custodian{
-	pixel_y = 30
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/sign/departments/custodian{
+	pixel_y = 30
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
@@ -19237,6 +19203,7 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "iQj" = (
@@ -19267,14 +19234,16 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "iRK" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/iron/dark/side,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/command/bridge)
 "iRN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -19303,15 +19272,23 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
+"iSm" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "iSv" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
@@ -19329,16 +19306,12 @@
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "iTi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "iTE" = (
 /obj/structure/rack,
@@ -19395,14 +19368,14 @@
 	id = "atmos";
 	name = "Atmospherics Blast Door"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/structure/cable,
+/obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "iVn" = (
@@ -19431,10 +19404,7 @@
 /area/service/hydroponics)
 "iVR" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "iWa" = (
@@ -19501,6 +19471,12 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/iron/airless,
 /area/space/nearstation)
+"iXy" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/cargo/office)
 "iXA" = (
 /obj/item/kirbyplants/random,
 /obj/effect/landmark/start/hangover,
@@ -19527,10 +19503,7 @@
 /turf/open/floor/carpet/red,
 /area/command/heads_quarters/hos)
 "iYb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark,
@@ -19572,13 +19545,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "iYo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/effect/landmark/start/cargo_technician,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "iYy" = (
@@ -19588,7 +19561,7 @@
 	},
 /obj/item/poster/random_contraband,
 /obj/item/bikehorn/golden,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "iYL" = (
 /obj/structure/disposalpipe/segment{
@@ -19643,16 +19616,10 @@
 /turf/open/floor/iron/solarpanel/airless,
 /area/solars/starboard/aft)
 "iZN" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "iZZ" = (
@@ -19721,12 +19688,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "jdJ" = (
@@ -19773,17 +19739,18 @@
 /area/medical/cryo)
 "jfm" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 8;
 	pixel_x = 30
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "jfs" = (
 /obj/effect/turf_decal/stripes/line{
@@ -19792,6 +19759,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/chapel/office)
+"jfv" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "jgi" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /obj/effect/decal/cleanable/dirt,
@@ -19841,19 +19814,6 @@
 	dir = 8
 	},
 /area/cargo/miningdock)
-"jhL" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "jhT" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L2"
@@ -19932,17 +19892,11 @@
 /turf/open/floor/iron/dark,
 /area/security/brig)
 "jjB" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/structure/chair{
 	dir = 8
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "jjU" = (
@@ -19953,6 +19907,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
+"jkD" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "jkF" = (
 /obj/structure/table/wood,
 /obj/effect/landmark/start/hangover,
@@ -20047,6 +20010,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "jny" = (
@@ -20068,6 +20034,9 @@
 	c_tag = "Fore Hallway - Art Storage";
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "jnN" = (
@@ -20076,12 +20045,12 @@
 /turf/open/openspace/airless,
 /area/solars/port/fore)
 "jod" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydroponics";
 	req_access_txt = "35"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
@@ -20114,21 +20083,12 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "jpn" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
@@ -20163,6 +20123,9 @@
 	dir = 1
 	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "jpX" = (
@@ -20177,14 +20140,12 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "jqj" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /turf/open/floor/iron,
-/area/security/brig)
+/area/hallway/primary/port)
 "jqq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -20193,14 +20154,14 @@
 /turf/open/floor/iron,
 /area/service/chapel)
 "jqt" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
 	},
 /obj/structure/window{
 	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
@@ -20215,6 +20176,9 @@
 "jqD" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "jqJ" = (
@@ -20249,11 +20213,10 @@
 	req_access_txt = "2"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
 /area/security/brig)
 "jri" = (
 /turf/closed/wall,
@@ -20268,16 +20231,12 @@
 /area/engineering/atmos)
 "jrH" = (
 /obj/item/radio/intercom/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/item/kirbyplants/random,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/obj/effect/spawner/randomcolavend,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jrM" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -20318,16 +20277,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "jst" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "jsw" = (
@@ -20337,28 +20296,18 @@
 	},
 /obj/machinery/firealarm/directional/south,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "jsz" = (
 /turf/closed/wall,
 /area/engineering/main)
 "jsE" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/table/glass,
 /obj/item/experi_scanner,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "jtc" = (
@@ -20377,15 +20326,12 @@
 /area/maintenance/port/fore)
 "jtk" = (
 /obj/machinery/light/small/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jtm" = (
 /obj/effect/turf_decal/stripes/line{
@@ -20410,16 +20356,8 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "jty" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "jtA" = (
@@ -20564,11 +20502,10 @@
 /area/science/xenobiology)
 "jwq" = (
 /obj/machinery/computer/crew,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "jwr" = (
@@ -20635,25 +20572,13 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Brig"
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/security/brig)
-"jwZ" = (
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/iron/dark/smooth_edge{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/cargo/office)
+/area/security/brig)
 "jxf" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/window{
@@ -20677,9 +20602,6 @@
 /area/hallway/secondary/entry)
 "jxD" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -20689,6 +20611,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "jxN" = (
@@ -20809,9 +20732,9 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jAB" = (
-/obj/structure/table,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/table,
 /obj/item/flashlight,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
@@ -20835,18 +20758,18 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "jAO" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron,
-/area/engineering/atmos)
+/area/hallway/primary/port)
 "jAQ" = (
 /obj/machinery/door/firedoor/heavy,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "jAX" = (
@@ -20867,6 +20790,12 @@
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "jBN" = (
@@ -20886,19 +20815,13 @@
 /turf/open/floor/grass,
 /area/cargo/office)
 "jBW" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Central Hallway - Kitchen";
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -20955,6 +20878,9 @@
 	c_tag = "Science - Xenobiology Central Upper";
 	network = list("ss13","rd")
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "jDo" = (
@@ -20995,6 +20921,9 @@
 	req_one_access_txt = "5"
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "jDK" = (
@@ -21007,7 +20936,7 @@
 	c_tag = "Security - Evidence";
 	network = list("ss13","prison")
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "jDP" = (
 /obj/machinery/camera{
@@ -21025,6 +20954,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "jEd" = (
@@ -21040,6 +20972,15 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"jFT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "jGl" = (
 /obj/machinery/door/airlock/external{
 	name = "Port Docking Bay 1";
@@ -21108,21 +21049,17 @@
 /turf/open/floor/iron/white,
 /area/medical/break_room)
 "jIk" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "jIn" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/security/brig)
 "jIN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -21192,6 +21129,9 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "jJG" = (
@@ -21227,6 +21167,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/south,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "jKf" = (
@@ -21257,10 +21200,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
@@ -21306,11 +21248,11 @@
 	},
 /area/hallway/secondary/entry)
 "jKU" = (
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 5
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "jKW" = (
@@ -21321,15 +21263,12 @@
 	name = "Security RC";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "jLa" = (
 /obj/structure/table,
@@ -21340,6 +21279,9 @@
 /area/maintenance/starboard/aft)
 "jLe" = (
 /obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "jLm" = (
@@ -21396,13 +21338,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "jMc" = (
@@ -21486,6 +21421,16 @@
 /obj/structure/closet/crate/trashcart/filled,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jPh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "jPr" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -21505,9 +21450,9 @@
 /turf/open/floor/iron/showroomfloor,
 /area/science/mixing/chamber)
 "jQg" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/corner,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "jQk" = (
@@ -21599,15 +21544,11 @@
 /area/command/bridge)
 "jSn" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/bounty_board/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/machinery/bounty_board/directional/west,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -21627,16 +21568,11 @@
 /turf/open/floor/iron/dark/textured,
 /area/engineering/lobby)
 "jSR" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/office)
 "jSV" = (
@@ -21708,12 +21644,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "jVh" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance{
 	name = "Custodial Maintenance";
 	req_access_txt = "26"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -21723,19 +21659,13 @@
 	name = "chapel sorting disposal pipe";
 	sortType = 17
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "jVn" = (
@@ -21981,11 +21911,7 @@
 /area/command/teleporter)
 "jZu" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/end{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/telecomms,
@@ -22081,14 +22007,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "kaY" = (
@@ -22120,9 +22045,10 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "kbn" = (
-/turf/open/floor/iron/dark/side{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
 	},
+/turf/open/floor/iron,
 /area/cargo/storage)
 "kbp" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -22135,23 +22061,17 @@
 /turf/open/floor/engine/co2,
 /area/engineering/atmos)
 "kbE" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "kbI" = (
@@ -22167,14 +22087,12 @@
 	name = "Security RC";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/iron,
+/obj/item/kirbyplants/random,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "kbU" = (
 /obj/machinery/light/cold/directional/east,
@@ -22287,13 +22205,7 @@
 /area/maintenance/department/science)
 "kdW" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "kdX" = (
@@ -22361,24 +22273,14 @@
 	},
 /area/engineering/main)
 "kfg" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab";
 	req_access_txt = "5; 33"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/white,
 /area/medical/chemistry)
 "kfr" = (
@@ -22437,10 +22339,7 @@
 /obj/item/cautery{
 	pixel_x = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "khh" = (
@@ -22467,7 +22366,7 @@
 /turf/open/floor/iron/checker,
 /area/service/hydroponics)
 "khA" = (
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "khQ" = (
 /turf/closed/wall,
@@ -22488,14 +22387,13 @@
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "kih" = (
-/obj/effect/turf_decal/tile/red{
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
 	},
-/obj/machinery/firealarm/directional/west,
-/turf/open/floor/iron,
 /area/security/brig)
 "kiu" = (
 /obj/structure/window/reinforced{
@@ -22569,7 +22467,7 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "kjT" = (
 /obj/machinery/vending/cigarette,
@@ -22671,7 +22569,7 @@
 	network = list("minisat")
 	},
 /turf/open/openspace/airless,
-/area/space/nearstation)
+/area/space)
 "kkY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22698,18 +22596,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "klr" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "klB" = (
@@ -22852,8 +22747,7 @@
 /turf/open/floor/iron/dark,
 /area/maintenance/disposal)
 "koG" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "koR" = (
@@ -22863,10 +22757,10 @@
 /turf/open/floor/carpet/black,
 /area/service/bar)
 "koU" = (
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "kpi" = (
@@ -22875,14 +22769,14 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "kpk" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /obj/structure/disposaloutlet{
 	dir = 8
 	},
 /obj/structure/window{
 	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/cargo/sorting)
@@ -22909,13 +22803,10 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "kqi" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "kqj" = (
@@ -22934,12 +22825,20 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/wood,
 /area/commons/dorms)
+"kqK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "kqS" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "krh" = (
@@ -22976,6 +22875,9 @@
 	pixel_x = 29
 	},
 /obj/structure/filingcabinet/chestdrawer,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "krN" = (
@@ -23020,8 +22922,20 @@
 /area/security/office)
 "ksy" = (
 /obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
+"ksC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "ksF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -23041,17 +22955,7 @@
 /area/engineering/main)
 "ksN" = (
 /obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/purple/filled/end,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "ksW" = (
@@ -23205,6 +23109,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "kvt" = (
@@ -23244,6 +23151,8 @@
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "kwf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light_switch{
 	pixel_x = 26;
 	pixel_y = -26
@@ -23254,8 +23163,6 @@
 	name = "service camera"
 	},
 /obj/machinery/firealarm/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
 "kwg" = (
@@ -23319,23 +23226,10 @@
 	},
 /area/command/gateway)
 "kxa" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/warning{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/railing/corner{
-	dir = 1
-	},
-/turf/open/floor/iron/dark,
+/turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "kxj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23471,14 +23365,15 @@
 /area/ai_monitored/command/nuke_storage)
 "kyP" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/bounty_board/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "kyW" = (
 /obj/effect/turf_decal/delivery,
@@ -23492,14 +23387,8 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "kzn" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "kzN" = (
@@ -23554,6 +23443,11 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
+"kBz" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/grass/green,
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "kBH" = (
 /obj/item/target,
 /obj/item/target,
@@ -23604,7 +23498,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "kCv" = (
 /obj/effect/turf_decal/tile/purple{
@@ -23663,6 +23563,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "kEQ" = (
@@ -24000,14 +23903,12 @@
 /turf/open/floor/iron,
 /area/engineering/storage)
 "kMQ" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "kMV" = (
@@ -24019,6 +23920,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
+"kMY" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/science/research)
 "kNp" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -24074,12 +23981,8 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -24126,20 +24029,20 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "kQf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "kQi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/sink/kitchen{
 	pixel_y = 20
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch{
 	pixel_x = 10;
 	pixel_y = 38
@@ -24157,11 +24060,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
-"kQn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/execution/transfer)
 "kQM" = (
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -24238,6 +24136,7 @@
 	pixel_y = -1
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "kSn" = (
@@ -24322,6 +24221,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "kTN" = (
@@ -24377,10 +24279,10 @@
 /turf/open/floor/iron/checker,
 /area/service/hydroponics)
 "kUD" = (
+/obj/effect/landmark/xeno_spawn,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen/coldroom)
 "kUH" = (
@@ -24396,17 +24298,11 @@
 	},
 /area/hallway/secondary/entry)
 "kUT" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/item/kirbyplants/random,
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "kVd" = (
@@ -24626,10 +24522,10 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "kZv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "kZD" = (
@@ -24658,12 +24554,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lae" = (
@@ -24671,12 +24570,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "las" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock{
 	name = "Bar Storage";
 	req_access_txt = "25"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
@@ -24726,11 +24625,7 @@
 /area/cargo/qm)
 "lcp" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/end{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/telecomms,
@@ -24739,6 +24634,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "lcP" = (
@@ -24764,6 +24662,9 @@
 /area/hallway/secondary/command)
 "ldh" = (
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ldl" = (
@@ -24790,10 +24691,10 @@
 /turf/open/floor/iron/white,
 /area/science/mixing)
 "ldq" = (
+/obj/effect/landmark/start/shaft_miner,
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "ldB" = (
@@ -24805,11 +24706,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "ldK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24822,10 +24719,7 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "ldS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/warning{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
@@ -24917,6 +24811,16 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/glass,
 /area/service/hydroponics)
+"lgI" = (
+/obj/effect/landmark/start/cargo_technician,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/office)
 "lgM" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
@@ -25014,10 +24918,6 @@
 /obj/machinery/computer/security{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -25026,8 +24926,8 @@
 	name = "Warden's RC";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
@@ -25042,9 +24942,16 @@
 /turf/open/floor/plating,
 /area/cargo/drone_boy)
 "liU" = (
-/obj/effect/decal/fakelattice,
-/turf/open/openspace/airless,
-/area/space/nearstation)
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 11;
+	height = 18;
+	id = "whiteship_home";
+	name = "SS13: Auxiliary Dock, Station-Lower";
+	width = 30
+	},
+/turf/open/space/basic,
+/area/space)
 "liV" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
@@ -25153,6 +25060,9 @@
 /turf/closed/wall,
 /area/security/courtroom)
 "lkd" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "lkk" = (
@@ -25186,12 +25096,9 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "lkZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "lla" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
@@ -25233,17 +25140,11 @@
 /turf/open/floor/carpet/royalblue,
 /area/command/corporate_showroom)
 "llP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/south,
 /obj/item/kirbyplants/random,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "llT" = (
@@ -25295,6 +25196,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/research)
 "lmB" = (
@@ -25403,6 +25305,9 @@
 	name = "lawyer sorting disposal pipe";
 	sortType = 29
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "lov" = (
@@ -25449,19 +25354,13 @@
 	name = "library sorting disposal pipe";
 	sortType = 16
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "lpH" = (
@@ -25477,6 +25376,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/qm)
 "lqm" = (
@@ -25551,10 +25453,10 @@
 "lso" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/corner,
+/turf/open/floor/iron/dark/smooth_corner,
 /area/security/brig)
 "lsu" = (
 /obj/structure/window,
@@ -25574,6 +25476,10 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"lsC" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "lsM" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/iron,
@@ -25620,11 +25526,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "lug" = (
@@ -25659,7 +25562,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "lvd" = (
 /obj/machinery/chem_master/condimaster{
@@ -25686,15 +25589,12 @@
 	pixel_x = 26;
 	req_access_txt = "2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "lvR" = (
 /obj/structure/table/glass,
@@ -25729,28 +25629,21 @@
 /turf/open/floor/iron,
 /area/command/teleporter)
 "lwn" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "lww" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/cargo/office)
 "lwA" = (
@@ -25995,18 +25888,8 @@
 /area/maintenance/department/medical)
 "lBP" = (
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/purple/filled/end,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "lCf" = (
@@ -26020,6 +25903,13 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/sepia,
 /area/service/chapel)
+"lCt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "lCv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/engine,
@@ -26059,16 +25949,13 @@
 /turf/open/floor/iron,
 /area/cargo/storage)
 "lEZ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "lFt" = (
@@ -26091,9 +25978,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/computer/cargo/request{
 	dir = 4
 	},
@@ -26102,13 +25986,16 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "lFT" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "lFY" = (
@@ -26178,6 +26065,9 @@
 "lHZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lIe" = (
@@ -26238,8 +26128,17 @@
 	c_tag = "Command - Starboard Bridge Hallway";
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
+"lIW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "lJj" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
@@ -26251,6 +26150,7 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "lJl" = (
@@ -26262,6 +26162,7 @@
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/status_display/evac/directional/north,
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "lJu" = (
@@ -26288,13 +26189,10 @@
 /turf/open/floor/iron/dark,
 /area/engineering/main)
 "lJL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -26306,10 +26204,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "lKc" = (
@@ -26487,12 +26382,6 @@
 /turf/open/floor/iron/smooth,
 /area/engineering/main)
 "lLJ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -26500,6 +26389,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
@@ -26526,6 +26418,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "lMA" = (
@@ -26600,15 +26495,14 @@
 	pixel_y = 2
 	},
 /obj/machinery/firealarm/directional/south,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/east{
 	broadcasting = 1;
 	frequency = 1447;
 	listening = 0;
 	name = "Station Intercom (AI Private)"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -26697,17 +26591,14 @@
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "lOV" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/firealarm/directional/north,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "lPf" = (
@@ -26812,13 +26703,7 @@
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lRO" = (
 /obj/structure/cable,
@@ -26827,18 +26712,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "lRP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/light/directional/west,
 /obj/structure/table,
 /obj/item/radio/intercom/directional/west,
 /obj/item/wirecutters,
 /obj/item/wrench,
 /obj/item/crowbar,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "lRU" = (
@@ -26910,15 +26792,11 @@
 /area/engineering/atmos)
 "lTq" = (
 /obj/machinery/stasis,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/light/cold/directional/south,
 /obj/machinery/defibrillator_mount/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "lTH" = (
@@ -26934,10 +26812,6 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "lTP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
@@ -26947,6 +26821,7 @@
 	name = "Medbay RC";
 	pixel_y = -30
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "lUf" = (
@@ -26978,6 +26853,7 @@
 	},
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/research)
 "lUp" = (
@@ -27011,17 +26887,18 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "lUL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/camera{
 	c_tag = "Security - External Airlock";
 	dir = 8;
 	network = list("ss13","prison")
 	},
 /obj/machinery/newscaster/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "lUM" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -27051,18 +26928,17 @@
 	},
 /area/maintenance/port)
 "lVq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/item/radio/intercom/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "lVt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "lVu" = (
@@ -27108,6 +26984,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"lWg" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "lWm" = (
 /turf/open/floor/engine,
 /area/engineering/supermatter)
@@ -27180,6 +27062,16 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
 /turf/open/floor/iron/dark,
 /area/science/mixing)
+"lXJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "lXL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -27187,21 +27079,35 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "lXN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
+"lXP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/cargo/office)
 "lYc" = (
 /turf/open/floor/carpet/black,
 /area/security/prison/workout)
 "lYk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "lYr" = (
@@ -27281,15 +27187,12 @@
 /area/science/research/abandoned)
 "maa" = (
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "mak" = (
@@ -27368,7 +27271,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "mbi" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -27406,14 +27309,7 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "mbr" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "mbt" = (
@@ -27474,16 +27370,16 @@
 /turf/open/floor/iron,
 /area/engineering/storage/tech)
 "mdq" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=2";
-	location = "1"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=2";
+	location = "1"
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "mdu" = (
@@ -27619,10 +27515,7 @@
 /area/hallway/secondary/entry)
 "mgn" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "mgB" = (
@@ -27630,6 +27523,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/service/kitchen)
 "mgD" = (
@@ -27652,6 +27548,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -27709,10 +27608,10 @@
 /turf/open/floor/wood/large,
 /area/service/library)
 "mie" = (
+/obj/effect/landmark/start/assistant,
 /obj/structure/chair/sofa/right{
 	name = "plush sofa"
 	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/service/bar)
 "min" = (
@@ -27734,6 +27633,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/grimy,
 /area/security/brig)
+"miL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "miV" = (
 /obj/structure/table,
 /obj/item/folder/red{
@@ -27781,6 +27695,13 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
+"mke" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "mkg" = (
 /obj/machinery/requests_console{
 	department = "Crew Quarters";
@@ -27792,15 +27713,8 @@
 /area/commons/dorms)
 "mkk" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
@@ -27936,10 +27850,7 @@
 /area/engineering/atmos)
 "mmE" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "mmF" = (
@@ -28039,13 +27950,6 @@
 /area/science/research)
 "moo" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -28058,6 +27962,9 @@
 	pixel_x = 8
 	},
 /obj/item/reagent_containers/syringe,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "mov" = (
@@ -28133,14 +28040,14 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "mpk" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
@@ -28229,10 +28136,9 @@
 /area/engineering/main)
 "mqr" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "mqy" = (
@@ -28240,13 +28146,7 @@
 /area/science/misc_lab)
 "mqB" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -28266,6 +28166,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "mqL" = (
@@ -28301,16 +28202,13 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "mqZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "mrd" = (
@@ -28340,14 +28238,10 @@
 /area/science/lab)
 "mrG" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron,
@@ -28444,6 +28338,9 @@
 "muu" = (
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "mux" = (
@@ -28520,19 +28417,19 @@
 	},
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/fire,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "mvS" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/fore)
 "mwf" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/iv_drip,
 /obj/structure/cable,
 /obj/item/radio/intercom/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "mwg" = (
@@ -28588,11 +28485,8 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "mxv" = (
@@ -28626,18 +28520,6 @@
 /obj/structure/table,
 /turf/open/floor/wood,
 /area/maintenance/central/secondary)
-"myd" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/hallway/primary/central)
 "mye" = (
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
@@ -28674,6 +28556,9 @@
 "mzr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "mzs" = (
@@ -28711,14 +28596,14 @@
 /turf/open/floor/iron/textured,
 /area/commons/fitness/recreation)
 "mzL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /obj/machinery/light/warm/directional/south,
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = -22
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
@@ -28778,6 +28663,9 @@
 	dir = 2
 	},
 /obj/effect/turf_decal/box,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/textured,
 /area/cargo/storage)
 "mBp" = (
@@ -28853,7 +28741,6 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2{
 	dir = 1
 	},
@@ -28930,6 +28817,9 @@
 /area/engineering/gravity_generator)
 "mEk" = (
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "mEs" = (
@@ -29038,10 +28928,10 @@
 	},
 /area/service/bar)
 "mHd" = (
+/obj/effect/landmark/start/assistant,
 /obj/structure/chair/sofa{
 	name = "plush sofa"
 	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/service/bar)
 "mHh" = (
@@ -29106,6 +28996,13 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"mIY" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "mJd" = (
 /obj/structure/table,
 /obj/item/hfr_box/body/fuel_input,
@@ -29226,6 +29123,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "mMI" = (
@@ -29250,13 +29150,10 @@
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "mMY" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "mMZ" = (
@@ -29277,6 +29174,12 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/security/prison)
+"mNe" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/treatment_center)
 "mNp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
@@ -29347,6 +29250,9 @@
 /area/service/hydroponics)
 "mOs" = (
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "mOv" = (
@@ -29472,12 +29378,13 @@
 "mQL" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "mQT" = (
+/obj/effect/landmark/start/shaft_miner,
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
-/obj/effect/landmark/start/shaft_miner,
 /obj/machinery/light_switch{
 	pixel_x = -10;
 	pixel_y = 22
@@ -29494,10 +29401,10 @@
 /turf/open/floor/iron,
 /area/maintenance/department/cargo)
 "mRo" = (
-/obj/structure/table,
-/obj/item/holosign_creator/robot_seat/restaurant,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/table,
+/obj/item/holosign_creator/robot_seat/restaurant,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "mRq" = (
@@ -29515,14 +29422,15 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/computer/security/telescreen/entertainment/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "mRA" = (
 /obj/structure/frame/computer{
@@ -29609,14 +29517,11 @@
 /area/science/research)
 "mSQ" = (
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/office)
 "mSZ" = (
@@ -29732,16 +29637,13 @@
 	pixel_y = 12
 	},
 /obj/item/retractor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/requests_console{
 	department = "Medical";
 	departmentType = 1;
 	name = "Medbay RC";
 	pixel_y = -30
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "mUs" = (
@@ -29787,24 +29689,15 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "mVB" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/bounty_board/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -29859,6 +29752,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/science,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "mXi" = (
@@ -29895,16 +29791,9 @@
 /area/hallway/secondary/service)
 "mXX" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "mYc" = (
@@ -29981,6 +29870,9 @@
 	dir = 4;
 	network = list("ss13","qm")
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/qm)
 "nap" = (
@@ -30019,14 +29911,27 @@
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
 "nbo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
+"nbG" = (
+/obj/machinery/door/firedoor,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyer";
+	name = "Medbay";
+	req_one_access_txt = "5"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "ncr" = (
 /obj/structure/table,
 /obj/item/food/cheesynachos{
@@ -30053,12 +29958,18 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
 "ncP" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "ncT" = (
 /obj/effect/turf_decal/stripes/line{
@@ -30178,6 +30089,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/security/brig)
+"neL" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "neN" = (
 /obj/machinery/light/small/red/directional/west,
 /obj/effect/spawner/bundle/moisture_trap,
@@ -30189,16 +30106,6 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
-"nfa" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "nfb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -30228,19 +30135,13 @@
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "nfQ" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/noticeboard{
 	dir = 8;
 	pixel_x = 32
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -30278,21 +30179,20 @@
 "ngd" = (
 /obj/machinery/door/firedoor,
 /obj/structure/fireaxecabinet/directional/west,
-/turf/open/floor/iron/dark/side,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
 /area/command/bridge)
 "ngh" = (
 /turf/closed/wall/r_wall,
 /area/science/misc_lab)
 "ngk" = (
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/flora/ausbushes/ywflowers,
-/turf/open/floor/grass,
-/area/service/hydroponics)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "ngr" = (
 /obj/structure/table,
 /obj/item/canvas/twentythree_twentythree,
@@ -30305,18 +30205,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "ngw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/security/brig)
 "ngI" = (
 /obj/machinery/door/airlock/atmos{
@@ -30362,14 +30261,8 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "nht" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "nhw" = (
@@ -30514,15 +30407,10 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "nkT" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
-/area/hallway/secondary/command)
+/area/hallway/primary/fore)
 "nld" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -30533,6 +30421,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"nlj" = (
+/obj/structure/closet{
+	anchored = 1;
+	can_be_unanchored = 1;
+	name = "Patient's Belongings"
+	},
+/obj/machinery/light/cold/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
 "nlv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -30580,19 +30480,19 @@
 /obj/machinery/computer/crew{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "nni" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "nnj" = (
@@ -30618,7 +30518,9 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/security/brig)
 "nnF" = (
 /turf/open/floor/iron/white/side,
@@ -30642,15 +30544,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "nnV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/table,
 /obj/machinery/firealarm/directional/north,
 /obj/item/stack/cable_coil,
@@ -30659,6 +30552,9 @@
 	pixel_y = -3
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "noo" = (
@@ -30707,14 +30603,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "noT" = (
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "npa" = (
 /obj/structure/weightmachine/weightlifter,
@@ -30729,12 +30622,8 @@
 	dir = 1
 	},
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
@@ -30779,10 +30668,13 @@
 /turf/open/floor/iron/dark,
 /area/science/xenobiology)
 "nrd" = (
+/obj/effect/landmark/start/assistant,
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "nre" = (
@@ -30865,23 +30757,16 @@
 /area/service/chapel)
 "nsM" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/power/apc/auto_name/north,
+/obj/effect/turf_decal/trimline/yellow/filled/end{
 	dir = 8
 	},
-/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "nsT" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "ntf" = (
@@ -30948,6 +30833,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "nuD" = (
+/obj/structure/cable,
 /obj/machinery/camera{
 	c_tag = "Cargo - Mining Office";
 	dir = 4;
@@ -30957,7 +30843,6 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "nuJ" = (
@@ -30995,6 +30880,9 @@
 /area/security/prison/garden)
 "nvx" = (
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "nvy" = (
@@ -31062,13 +30950,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "nxe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/line{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/side{
@@ -31136,13 +31025,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/stripes/line,
 /obj/effect/landmark/event_spawn,
 /obj/effect/landmark/blobstart,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron,
 /area/cargo/drone_boy)
 "nxU" = (
@@ -31165,20 +31054,10 @@
 /turf/open/floor/iron,
 /area/service/library)
 "nyg" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/chair{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/end,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "nyi" = (
@@ -31187,12 +31066,11 @@
 	},
 /area/science/test_area)
 "nym" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/bounty_board/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/security/brig)
 "nyn" = (
 /obj/machinery/door/airlock/command/glass{
@@ -31227,16 +31105,8 @@
 /turf/open/floor/iron/dark,
 /area/science/research)
 "nzg" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/effect/turf_decal/trimline/purple/filled/end{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
@@ -31245,6 +31115,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "nzC" = (
@@ -31290,13 +31163,10 @@
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "nAw" = (
@@ -31312,13 +31182,9 @@
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
 "nAR" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "nAS" = (
@@ -31503,8 +31369,7 @@
 /area/service/chapel)
 "nEw" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -31521,6 +31386,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "nEQ" = (
@@ -31803,20 +31669,17 @@
 /turf/open/floor/grass,
 /area/service/chapel)
 "nIC" = (
-/obj/effect/turf_decal/tile/red{
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "nID" = (
-/obj/machinery/light/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/light/directional/south,
 /obj/machinery/requests_console{
 	department = "Kitchen";
 	departmentType = 2;
@@ -31834,12 +31697,11 @@
 	dir = 8
 	},
 /obj/machinery/newscaster/directional/east,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
 /area/medical/cryo)
@@ -31959,6 +31821,9 @@
 /area/hallway/primary/aft)
 "nKL" = (
 /obj/structure/noticeboard/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "nKX" = (
@@ -32018,22 +31883,27 @@
 /turf/open/floor/engine/n2o,
 /area/engineering/atmos)
 "nLD" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "nLH" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
+"nLV" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
+/area/security/brig)
 "nLW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32064,16 +31934,6 @@
 /obj/machinery/bounty_board/directional/north,
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
-"nMY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/iron,
-/area/security/execution/transfer)
 "nMZ" = (
 /obj/structure/window{
 	dir = 4
@@ -32125,14 +31985,15 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "nNC" = (
 /obj/structure/bodycontainer/morgue,
@@ -32156,11 +32017,8 @@
 "nOY" = (
 /mob/living/simple_animal/bot/cleanbot,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/power/apc/auto_name/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "nPj" = (
@@ -32227,13 +32085,14 @@
 "nSY" = (
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "nTs" = (
 /obj/machinery/airalarm/directional/south,
@@ -32282,25 +32141,10 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "nTR" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
-"nUj" = (
-/obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/security/brig)
 "nUl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32344,6 +32188,9 @@
 /area/medical/virology)
 "nVd" = (
 /obj/structure/closet/crate/bin,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "nVe" = (
@@ -32470,15 +32317,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "nYG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "nYL" = (
@@ -32502,6 +32352,9 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "nZk" = (
@@ -32519,12 +32372,6 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "nZD" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
@@ -32630,18 +32477,15 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "ocl" = (
 /obj/item/radio/intercom/directional/south,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "ocL" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera{
 	c_tag = "Medbay - Cryogenics";
 	dir = 1;
@@ -32659,6 +32503,7 @@
 	},
 /obj/item/wrench/medical,
 /obj/item/storage/pill_bottle/mannitol,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "ocU" = (
@@ -32677,14 +32522,11 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/hop)
 "odd" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/status_display/evac/directional/north,
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "odo" = (
@@ -32715,14 +32557,10 @@
 /area/command/corporate_showroom)
 "odY" = (
 /obj/machinery/telecomms/server/presets/common,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/trimline/neutral/filled/end{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "oeg" = (
@@ -32742,8 +32580,7 @@
 /area/engineering/supermatter)
 "oeS" = (
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -32768,18 +32605,11 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "ofP" = (
@@ -32850,11 +32680,10 @@
 	},
 /area/maintenance/starboard/aft)
 "ohs" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ohV" = (
@@ -32950,7 +32779,7 @@
 /area/medical/virology)
 "ojm" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "ojA" = (
 /obj/structure/disposalpipe/segment,
@@ -32966,10 +32795,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ojT" = (
@@ -32991,11 +32817,8 @@
 /turf/closed/wall,
 /area/medical/patients_rooms)
 "okb" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -33023,15 +32846,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "okO" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "okU" = (
@@ -33111,15 +32930,10 @@
 /turf/open/floor/iron/grimy,
 /area/security/detectives_office)
 "oln" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/cable,
+/obj/machinery/airalarm/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "olu" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	name = "n2o to primary mix";
@@ -33135,13 +32949,9 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
 "olF" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "olH" = (
@@ -33174,7 +32984,7 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/firealarm/directional/south,
 /obj/structure/table,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "omJ" = (
 /obj/machinery/power/terminal{
@@ -33193,10 +33003,16 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "onH" = (
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "onT" = (
@@ -33226,6 +33042,9 @@
 /obj/machinery/holopad,
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/science/lab)
 "ooC" = (
@@ -33338,12 +33157,12 @@
 /turf/open/floor/iron/grimy,
 /area/security/prison/rec)
 "orE" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/cargo/office)
 "orH" = (
@@ -33382,16 +33201,13 @@
 	c_tag = "Security - Brigmed";
 	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "osj" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -33554,13 +33370,10 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ous" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/status_display/evac{
-	pixel_x = 32
-	},
+/obj/machinery/status_display/evac/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "oux" = (
@@ -33588,15 +33401,9 @@
 /area/maintenance/department/cargo)
 "owx" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -33604,6 +33411,9 @@
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/computer/security/telescreen/entertainment/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "owM" = (
@@ -33650,6 +33460,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "oxT" = (
@@ -33660,12 +33473,6 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/command)
 "oyc" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -33683,6 +33490,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "oyL" = (
@@ -33703,14 +33513,10 @@
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
 "oyQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "oyV" = (
 /obj/effect/decal/cleanable/generic,
@@ -33758,6 +33564,7 @@
 /obj/item/pen,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "ozr" = (
@@ -33775,6 +33582,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ozu" = (
@@ -33795,14 +33605,16 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/gloves/color/latex/nitrile,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "ozY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "ozZ" = (
 /obj/machinery/door/window/eastright{
@@ -33917,6 +33729,7 @@
 "oDz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "oDB" = (
@@ -33975,6 +33788,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "oEB" = (
@@ -34027,6 +33843,13 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"oFH" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "oFN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/cafeteria,
@@ -34072,12 +33895,11 @@
 /obj/machinery/computer/cargo/request{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/light/directional/south,
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "oGs" = (
@@ -34142,11 +33964,10 @@
 /turf/open/floor/iron/dark,
 /area/cargo/miningdock)
 "oHL" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "oIa" = (
@@ -34203,32 +34024,28 @@
 /turf/open/floor/iron/freezer,
 /area/security/prison/shower)
 "oJl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Kitchen Cold Room";
 	req_access_txt = "28"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
-/obj/machinery/duct,
-/obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/service/kitchen)
 "oJs" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/door_timer{
 	id = "Cell 3";
 	name = "Cell 3";
 	pixel_y = -32
 	},
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "oJx" = (
 /obj/item/clothing/under/rank/prisoner/skirt,
@@ -34301,6 +34118,12 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/iron,
 /area/command/gateway)
+"oKQ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "oKR" = (
 /obj/structure/grille/broken,
 /obj/structure/cable,
@@ -34328,6 +34151,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
+"oLS" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "oMf" = (
 /obj/structure/window,
 /obj/structure/window{
@@ -34428,14 +34257,8 @@
 /turf/open/floor/engine/plasma,
 /area/engineering/atmos)
 "oNN" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/end{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
@@ -34503,6 +34326,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "oPj" = (
@@ -34518,14 +34344,13 @@
 /turf/open/floor/grass,
 /area/security/prison/garden)
 "oPC" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "oPL" = (
@@ -34628,13 +34453,6 @@
 /area/maintenance/starboard/aft)
 "oRG" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "oRX" = (
@@ -34692,10 +34510,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "oSQ" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = 11
@@ -34739,13 +34553,7 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "oSW" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "oTa" = (
@@ -34786,13 +34594,6 @@
 /obj/item/reagent_containers/blood/b_minus,
 /obj/item/reagent_containers/blood/a_plus,
 /obj/item/reagent_containers/blood/a_minus,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -34800,6 +34601,9 @@
 	},
 /obj/machinery/power/apc/auto_name/east,
 /obj/machinery/light/cold/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "oUd" = (
@@ -34812,9 +34616,9 @@
 /area/security/prison/garden)
 "oUJ" = (
 /obj/structure/cable,
-/obj/machinery/power/apc/auto_name/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/power/apc/auto_name/west,
 /turf/open/floor/iron,
 /area/cargo/office)
 "oVj" = (
@@ -34887,13 +34691,6 @@
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "oVX" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
@@ -34930,17 +34727,14 @@
 	},
 /area/maintenance/fore)
 "oWO" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "oWV" = (
@@ -34979,6 +34773,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "oXJ" = (
@@ -35030,6 +34827,9 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "oYU" = (
@@ -35050,24 +34850,26 @@
 /area/maintenance/starboard/aft)
 "oZn" = (
 /obj/item/radio/intercom/directional/south,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
+/area/security/brig)
+"oZt" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
-/area/security/brig)
+/area/cargo/office)
 "oZH" = (
 /turf/closed/wall/r_wall,
 /area/science/breakroom)
 "oZL" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
@@ -35143,18 +34945,9 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/openspace/airless,
 /area/engineering/atmos)
 "pbt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35163,6 +34956,12 @@
 	c_tag = "Engineering - Airlock";
 	dir = 4;
 	network = list("ss13","engine")
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/engineering/lobby)
@@ -35194,6 +34993,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
+"pct" = (
+/obj/effect/turf_decal/trimline/green/filled/corner,
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "pcD" = (
 /obj/item/reagent_containers/glass/bottle/multiver{
 	pixel_x = 7;
@@ -35273,12 +35079,12 @@
 	id = "bridge blast";
 	name = "bridge blast door"
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/command)
 "pdO" = (
@@ -35302,26 +35108,19 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "pdT" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/requests_console{
 	department = "Medical";
 	departmentType = 1;
 	name = "Medbay RC";
 	pixel_y = -30
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "pdU" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
@@ -35348,6 +35147,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "peG" = (
@@ -35394,6 +35196,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "pfQ" = (
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "pfU" = (
@@ -35516,35 +35319,30 @@
 /turf/open/floor/iron/dark,
 /area/medical/morgue)
 "phN" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "phQ" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "phS" = (
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/machinery/light/directional/east,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "pib" = (
@@ -35556,6 +35354,9 @@
 /obj/structure/cable,
 /obj/machinery/duct,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "piC" = (
@@ -35634,6 +35435,9 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "pky" = (
@@ -35646,10 +35450,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "pkL" = (
@@ -35664,6 +35464,13 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/white,
 /area/science/research)
+"pln" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/cargo/qm)
 "plw" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/visible,
@@ -35682,6 +35489,12 @@
 "plS" = (
 /obj/machinery/duct,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "pmi" = (
@@ -35711,12 +35524,22 @@
 /turf/open/floor/engine/vacuum,
 /area/engineering/atmos)
 "pnm" = (
+/obj/effect/landmark/start/cargo_technician,
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/effect/landmark/start/cargo_technician,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/office)
+"pnp" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "pns" = (
 /obj/item/trash/candy{
 	pixel_x = -5
@@ -35825,13 +35648,10 @@
 /area/science/misc_lab)
 "ppv" = (
 /obj/structure/bed/dogbed/mcgriff,
-/obj/effect/turf_decal/tile/red{
+/mob/living/simple_animal/pet/dog/pug/mcgriff,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/mob/living/simple_animal/pet/dog/pug/mcgriff,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "ppw" = (
@@ -35865,10 +35685,9 @@
 	dir = 8
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/effect/turf_decal/trimline/brown/filled/end{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -35960,18 +35779,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "psE" = (
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "psL" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Art Storage"
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/public/glass{
+	name = "Art Storage"
+	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/storage/art)
@@ -35980,6 +35805,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
+"ptf" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "ptq" = (
 /obj/structure/chair/sofa/left,
 /obj/item/toy/plush/moth,
@@ -36023,7 +35854,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "ptM" = (
 /obj/structure/cable,
@@ -36053,13 +35884,14 @@
 /turf/open/floor/carpet/black,
 /area/security/prison/workout)
 "pud" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "puj" = (
 /obj/machinery/power/apc/auto_name/east,
@@ -36083,22 +35915,19 @@
 	pixel_x = -6;
 	pixel_y = 26
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "pus" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Aft Hallway - Custodial Closet";
 	dir = 1;
 	view_range = 10
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "puM" = (
@@ -36189,12 +36018,12 @@
 /turf/open/floor/carpet/black,
 /area/service/bar)
 "pyb" = (
+/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/xeno_spawn,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "pyc" = (
@@ -36236,11 +36065,8 @@
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/keycard_auth/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/end,
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "pzA" = (
@@ -36249,14 +36075,13 @@
 /turf/open/floor/iron/dark,
 /area/command/teleporter)
 "pzK" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/cryo_cell{
 	dir = 8
 	},
 /obj/machinery/light/cold/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white/textured,
 /area/medical/cryo)
 "pzO" = (
@@ -36282,6 +36107,9 @@
 "pAc" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/medical_doctor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pAf" = (
@@ -36307,15 +36135,12 @@
 /area/maintenance/central/secondary)
 "pAH" = (
 /mob/living/simple_animal/bot/floorbot,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "MiniSat - Antechamber";
 	network = list("minisat")
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -36353,10 +36178,13 @@
 /turf/open/floor/plating,
 /area/security/prison/work)
 "pCn" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/bot,
 /obj/structure/chair/stool/bar{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
@@ -36371,6 +36199,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/science,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "pCB" = (
@@ -36385,15 +36216,20 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "pCH" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "pCR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "pCS" = (
@@ -36448,6 +36284,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "pDq" = (
@@ -36533,10 +36375,11 @@
 /turf/open/openspace,
 /area/science/xenobiology)
 "pFf" = (
-/obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/cable,
-/turf/open/floor/iron/dark/smooth_large,
-/area/hallway/secondary/service)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "pFh" = (
 /obj/machinery/camera{
 	c_tag = "Science - Xenobiology Central Lower";
@@ -36558,10 +36401,13 @@
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/port)
 "pFX" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/railing{
 	dir = 4
 	},
-/obj/structure/railing{
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -36573,14 +36419,11 @@
 "pGj" = (
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "pGs" = (
@@ -36599,7 +36442,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "pGI" = (
 /obj/machinery/door/airlock/external{
@@ -36621,13 +36464,16 @@
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "pGS" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/camera{
 	c_tag = "Science - Aft Hallway";
 	dir = 5;
 	network = list("ss13","rd")
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/science/research)
 "pGV" = (
@@ -36661,7 +36507,13 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "pHr" = (
 /obj/structure/table/wood,
@@ -36690,15 +36542,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pHz" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "pIe" = (
 /obj/machinery/light/small/directional/south,
@@ -36711,7 +36559,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/turf/open/floor/iron/showroomfloor,
+/turf/open/floor/iron/dark,
 /area/security/warden)
 "pIp" = (
 /obj/structure/chair/office{
@@ -36851,7 +36699,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "pJR" = (
 /turf/closed/wall,
@@ -36863,14 +36711,11 @@
 /area/science/robotics/lab)
 "pKc" = (
 /obj/machinery/stasis,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/light/cold/directional/west,
 /obj/machinery/defibrillator_mount/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "pKe" = (
@@ -36882,6 +36727,9 @@
 "pKm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/cargo/qm)
@@ -36895,8 +36743,8 @@
 /area/hallway/secondary/entry)
 "pKy" = (
 /obj/structure/cable,
-/obj/machinery/light/small/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "pKD" = (
@@ -36914,6 +36762,13 @@
 "pKH" = (
 /turf/open/floor/iron,
 /area/science/server)
+"pKN" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/cargo/storage)
 "pKU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -36939,12 +36794,25 @@
 	},
 /turf/open/floor/iron,
 /area/commons/storage/art)
+"pLl" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "pLq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/maintenance/central/secondary)
+"pLy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "pLM" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/trimline/green/line,
@@ -36960,14 +36828,14 @@
 /area/security/prison)
 "pMl" = (
 /obj/effect/landmark/start/cargo_technician,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "pMq" = (
@@ -37019,10 +36887,13 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "pNc" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/bot,
 /obj/structure/chair/stool/bar{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
@@ -37046,35 +36917,21 @@
 /area/hallway/secondary/exit)
 "pOz" = (
 /obj/machinery/telecomms/server/presets/service,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/obj/effect/turf_decal/trimline/green/filled/end{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "pOK" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "pOT" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -37089,10 +36946,13 @@
 /turf/closed/wall,
 /area/hallway/primary/starboard)
 "pPk" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/closet/emcloset,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "pPu" = (
@@ -37157,9 +37017,6 @@
 /turf/open/floor/vault,
 /area/ai_monitored/command/nuke_storage)
 "pRj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/status_display/supply{
 	pixel_y = 30
 	},
@@ -37167,6 +37024,12 @@
 /obj/machinery/camera{
 	c_tag = "Cargo - Mech Pad";
 	network = list("ss13","qm")
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/cargo/storage)
@@ -37194,12 +37057,12 @@
 	},
 /area/maintenance/fore)
 "pSy" = (
+/obj/structure/cable,
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/camera{
 	c_tag = "Service - Library East";
 	dir = 8
 	},
-/obj/structure/cable,
 /turf/open/floor/wood,
 /area/service/library)
 "pSB" = (
@@ -37214,7 +37077,7 @@
 	name = "Evidence Closet"
 	},
 /obj/item/bikehorn/airhorn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "pSE" = (
 /obj/structure/chair{
@@ -37309,6 +37172,9 @@
 /obj/effect/landmark/start/depsec/medical,
 /obj/machinery/firealarm/directional/east,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "pUw" = (
@@ -37328,18 +37194,14 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "pUA" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/camera{
 	c_tag = "Escape Hallway - EVA";
 	dir = 4
 	},
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "pUC" = (
@@ -37354,25 +37216,18 @@
 /turf/open/floor/iron/dark,
 /area/engineering/storage)
 "pUK" = (
+/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
 /obj/machinery/light_switch{
 	pixel_x = -20;
 	pixel_y = 11
 	},
-/obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "pUV" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -37383,6 +37238,9 @@
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "pVo" = (
@@ -37422,26 +37280,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "pWt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/chair/office{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
@@ -37488,10 +37340,7 @@
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
 "pYt" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -37512,6 +37361,13 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/wood,
 /area/commons/vacant_room/office)
+"pYK" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/obj/effect/turf_decal/trimline/green/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "pYS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/orange/visible,
 /turf/closed/wall/r_wall,
@@ -37535,15 +37391,9 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "pZs" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/item/kirbyplants/random,
 /obj/machinery/bounty_board/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "pZw" = (
@@ -37558,16 +37408,15 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "pZx" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/door_timer{
 	id = "Cell 2";
 	name = "Cell 2";
 	pixel_y = -32
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/security/brig)
 "pZD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -37652,6 +37501,9 @@
 "qaQ" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "qaU" = (
@@ -37659,6 +37511,7 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/research)
 "qaV" = (
@@ -37715,6 +37568,9 @@
 /area/security/courtroom)
 "qbB" = (
 /obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "qbP" = (
@@ -37730,6 +37586,9 @@
 "qci" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/qm)
 "qcN" = (
@@ -37744,7 +37603,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "qdl" = (
 /obj/item/stack/rods/fifty,
@@ -37786,6 +37645,15 @@
 /obj/structure/stairs/south,
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
+"qeM" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "qeO" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plating,
@@ -37946,12 +37814,18 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "qiP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "qja" = (
@@ -37970,14 +37844,8 @@
 /turf/open/floor/iron,
 /area/commons/fitness/recreation)
 "qjw" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "qjy" = (
@@ -38056,14 +37924,17 @@
 	pixel_x = 24;
 	pixel_y = -5
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron,
 /area/cargo/qm)
 "qlk" = (
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "qlz" = (
@@ -38124,15 +37995,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "qmR" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "qmV" = (
@@ -38199,9 +38067,8 @@
 	pixel_x = 9;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -38358,19 +38225,16 @@
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "qqP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 17
 	},
 /obj/machinery/status_display/evac/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "qqQ" = (
@@ -38420,6 +38284,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "qst" = (
@@ -38427,6 +38292,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "qsE" = (
@@ -38505,12 +38376,6 @@
 /area/commons/dorms)
 "quP" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/north,
@@ -38518,7 +38383,10 @@
 	c_tag = "Security - Cells";
 	network = list("ss13","prison")
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "quV" = (
 /obj/structure/cable,
@@ -38653,6 +38521,7 @@
 	name = "Quartermaster RC";
 	pixel_y = -30
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/qm)
 "qwY" = (
@@ -38693,6 +38562,7 @@
 /area/cargo/miningdock)
 "qxp" = (
 /obj/effect/spawner/randomcolavend,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "qxx" = (
@@ -38710,6 +38580,9 @@
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
 /obj/machinery/bounty_board/directional/north,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "qxD" = (
@@ -38781,21 +38654,15 @@
 /turf/open/floor/iron,
 /area/tcommsat/computer)
 "qyF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "qyG" = (
 /turf/open/floor/iron/showroomfloor,
@@ -38867,6 +38734,9 @@
 "qAm" = (
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
@@ -38945,6 +38815,10 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/port)
+"qDh" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner,
+/turf/open/floor/iron,
+/area/cargo/storage)
 "qDt" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
 	dir = 4
@@ -38976,12 +38850,12 @@
 	},
 /area/engineering/main)
 "qDV" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -38999,13 +38873,9 @@
 /area/hallway/primary/fore)
 "qEn" = (
 /obj/machinery/telecomms/server/presets/engineering,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/end{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "qEA" = (
@@ -39041,8 +38911,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "qEV" = (
-/obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -39090,14 +38963,21 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "qGd" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/railing/corner{
 	dir = 4
 	},
-/obj/structure/railing/corner{
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
+"qGr" = (
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/turf/open/floor/iron,
+/area/cargo/office)
 "qGs" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39105,6 +38985,16 @@
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"qGz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/cryo)
 "qGL" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister,
@@ -39133,15 +39023,9 @@
 /turf/open/floor/grass,
 /area/medical/medbay/lobby)
 "qHg" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/status_display/evac/directional/east,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -39335,14 +39219,10 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "qMG" = (
-/obj/effect/turf_decal/tile/red{
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "qMI" = (
@@ -39367,17 +39247,19 @@
 /obj/machinery/computer/operating{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/light/cold/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
+"qNN" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "qNS" = (
 /obj/structure/closet/emcloset{
 	anchored = 1
@@ -39407,6 +39289,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "qOo" = (
@@ -39457,6 +39342,9 @@
 /turf/open/floor/plating,
 /area/science/lab)
 "qPx" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "qPD" = (
@@ -39639,6 +39527,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "qSY" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "qTf" = (
@@ -39690,13 +39581,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "qTX" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "qUf" = (
@@ -39886,13 +39771,10 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "qYZ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "qZc" = (
@@ -39905,23 +39787,20 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "qZB" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/camera{
 	c_tag = "Command - Starboard Bridge Entrance";
 	dir = 4
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "qZD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/computer/security{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -39998,10 +39877,6 @@
 	},
 /obj/machinery/light/directional/north,
 /obj/machinery/modular_computer/console/preset/cargochat/cargo,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "rbp" = (
@@ -40065,12 +39940,6 @@
 /area/science/xenobiology)
 "rcl" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
@@ -40139,6 +40008,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rdu" = (
@@ -40148,6 +40020,9 @@
 /obj/structure/cable,
 /obj/machinery/door/firedoor,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rdD" = (
@@ -40197,15 +40072,18 @@
 "reD" = (
 /obj/machinery/power/apc/auto_name/east,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/qm)
 "reF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/duct,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "reO" = (
@@ -40297,6 +40175,9 @@
 /area/command/heads_quarters/captain/private)
 "rgv" = (
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "rgw" = (
@@ -40305,6 +40186,7 @@
 /area/maintenance/fore)
 "rgC" = (
 /obj/effect/landmark/start/medical_doctor,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "rgW" = (
@@ -40323,6 +40205,9 @@
 /obj/machinery/airalarm/directional/north,
 /obj/vehicle/ridden/wheelchair,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "rhX" = (
@@ -40362,6 +40247,9 @@
 "rjN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -40433,16 +40321,25 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "rlM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "kitchen";
 	name = "Serving Hatch"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/service/kitchen)
+"rlP" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "rlT" = (
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
@@ -40639,8 +40536,7 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "rql" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron,
@@ -40650,11 +40546,11 @@
 /area/maintenance/aft)
 "rqF" = (
 /obj/effect/landmark/start/hangover,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/chair/stool/bar{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/service/bar)
 "rqM" = (
@@ -40662,12 +40558,12 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "rrn" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "rrQ" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
@@ -40758,6 +40654,12 @@
 "rsK" = (
 /turf/closed/wall,
 /area/security/prison/work)
+"rsW" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "rsX" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/machinery/light/directional/east,
@@ -40772,6 +40674,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/power/apc/auto_name/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "rtA" = (
@@ -40848,16 +40753,15 @@
 /turf/open/floor/iron/dark,
 /area/ai_monitored/command/storage/satellite)
 "ruE" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "ruH" = (
@@ -40946,6 +40850,7 @@
 /area/engineering/break_room)
 "rvE" = (
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "rvN" = (
@@ -40958,6 +40863,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "rvU" = (
@@ -41027,12 +40935,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
 /area/security/brig)
+"rym" = (
+/obj/machinery/medical_kiosk,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "ryH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41047,6 +40961,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"ryW" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "ryX" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/conveyor_switch/oneway{
@@ -41134,6 +41057,9 @@
 /area/service/library)
 "rAN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/cryo)
 "rAS" = (
@@ -41151,13 +41077,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
-"rBy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
-/area/security/brig)
 "rBI" = (
 /obj/structure/flora/ausbushes/sunnybush,
 /obj/effect/landmark/blobstart,
@@ -41168,13 +41087,6 @@
 	c_tag = "Starboard Hallway - Aft Corner";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "rBM" = (
@@ -41199,14 +41111,14 @@
 /turf/open/floor/grass,
 /area/science/genetics)
 "rCI" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Delivery Office";
 	req_access_txt = "50"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "rCJ" = (
@@ -41251,6 +41163,7 @@
 	dir = 8
 	},
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/dark,
 /area/cargo/qm)
 "rEg" = (
@@ -41275,6 +41188,12 @@
 "rEG" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/command/heads_quarters/cmo)
@@ -41311,17 +41230,14 @@
 /turf/open/floor/iron,
 /area/commons/storage/art)
 "rFS" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/status_display/evac/directional/north,
 /obj/machinery/camera{
 	c_tag = "Port Hallway - Security"
 	},
 /obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "rGa" = (
@@ -41360,12 +41276,18 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Recovery Room B"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "rHG" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -41418,12 +41340,14 @@
 /area/hallway/primary/aft)
 "rIC" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "rIL" = (
 /obj/structure/closet,
@@ -41462,15 +41386,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "rJl" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/line,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "rJr" = (
@@ -41527,6 +41449,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/research)
 "rKn" = (
@@ -41656,41 +41579,29 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "rMB" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=1";
 	location = "0"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "rMS" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/effect/turf_decal/siding/blue/corner{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "rMW" = (
@@ -41745,6 +41656,7 @@
 /obj/structure/sign/departments/security{
 	pixel_y = 34
 	},
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "rNX" = (
@@ -41822,14 +41734,15 @@
 /area/engineering/atmos)
 "rQc" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "rQp" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible,
@@ -41860,44 +41773,34 @@
 /turf/open/floor/iron/dark,
 /area/science/mixing)
 "rQU" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/structure/noticeboard/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/noticeboard/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "rQZ" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "rRf" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/airalarm/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "rRj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "rRm" = (
@@ -41950,10 +41853,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/security/brig)
 "rSU" = (
 /obj/machinery/bounty_board/directional/north,
@@ -41982,11 +41887,10 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "rTi" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
 	},
-/turf/open/floor/iron,
 /area/security/brig)
 "rTq" = (
 /obj/effect/turf_decal/stripes/line{
@@ -41996,14 +41900,14 @@
 	id = "atmos";
 	name = "Atmospherics Blast Door"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/obj/machinery/door/firedoor/heavy,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/door/firedoor/heavy,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "rTv" = (
@@ -42012,15 +41916,18 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "rTD" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/camera{
 	c_tag = "Cargo - Office";
 	dir = 4;
 	network = list("ss13","qm")
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "rTG" = (
@@ -42100,8 +42007,7 @@
 /obj/structure/cable,
 /obj/machinery/light/directional/east,
 /obj/effect/landmark/start/cyborg,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -42118,18 +42024,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
 /area/tcommsat/computer)
-"rVS" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "rWa" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -42259,15 +42153,9 @@
 /turf/open/floor/iron/grimy,
 /area/maintenance/central/secondary)
 "rYs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "rYy" = (
 /obj/machinery/light/directional/north,
@@ -42281,6 +42169,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "rYB" = (
@@ -42366,11 +42255,10 @@
 /area/space)
 "sal" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/computer/security/telescreen/entertainment/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen/entertainment/directional/east,
 /turf/open/floor/iron,
 /area/security/courtroom)
 "sau" = (
@@ -42394,6 +42282,9 @@
 	dir = 1
 	},
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "sbw" = (
@@ -42471,7 +42362,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
 /area/security/brig)
 "scc" = (
 /obj/structure/cable,
@@ -42498,10 +42394,6 @@
 /turf/open/floor/iron,
 /area/engineering/break_room)
 "scu" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/light_switch{
 	pixel_x = -10;
@@ -42509,6 +42401,7 @@
 	},
 /obj/machinery/power/apc/auto_name/south,
 /obj/machinery/light/cold/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "scy" = (
@@ -42567,14 +42460,10 @@
 /turf/open/floor/plating,
 /area/engineering/break_room)
 "sdh" = (
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/window,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/structure/flora/grass/green,
-/turf/open/floor/grass,
-/area/service/hydroponics)
+/obj/machinery/light/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "sdl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -42682,11 +42571,7 @@
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "sfj" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/end{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/telecomms,
@@ -42716,6 +42601,9 @@
 "sfR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -42774,6 +42662,9 @@
 /area/maintenance/disposal/incinerator)
 "shX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron/white,
@@ -42924,14 +42815,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "skI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "skP" = (
@@ -42945,26 +42839,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "skX" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	name = "medical sorting disposal pipe";
-	sortType = 9
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "slc" = (
@@ -42999,21 +42884,15 @@
 /turf/closed/wall,
 /area/maintenance/department/cargo)
 "slB" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/camera{
 	c_tag = "Aft Hallway - Intersection";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "slO" = (
@@ -43063,6 +42942,12 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/port/fore)
+"sok" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "soq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -43142,9 +43027,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/engineering/atmos/experiment_room)
+"sqz" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "sqF" = (
 /obj/structure/cable,
 /obj/effect/landmark/start/medical_doctor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "sqI" = (
@@ -43263,6 +43158,9 @@
 "srT" = (
 /obj/structure/cable,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "ssb" = (
@@ -43282,7 +43180,7 @@
 /obj/item/target/syndicate,
 /obj/structure/training_machine,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/range)
 "ssG" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
@@ -43303,6 +43201,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/office)
 "stj" = (
@@ -43314,14 +43213,15 @@
 	dir = 8;
 	network = list("ss13","prison")
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/evac/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "stD" = (
 /obj/machinery/light/directional/north,
@@ -43349,16 +43249,10 @@
 /turf/open/floor/iron/white,
 /area/security/brig)
 "suc" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "sum" = (
@@ -43422,6 +43316,9 @@
 "swv" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/window{
+	dir = 4
+	},
 /turf/open/floor/grass,
 /area/service/hydroponics)
 "swN" = (
@@ -43524,6 +43421,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "syK" = (
@@ -43533,14 +43431,14 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "syT" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "syU" = (
@@ -43673,18 +43571,15 @@
 /turf/open/floor/carpet/cyan,
 /area/hallway/primary/starboard)
 "sBy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/machinery/newscaster/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "sBz" = (
 /obj/machinery/camera{
@@ -43710,6 +43605,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "sBT" = (
@@ -43723,17 +43621,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "sCg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "sCi" = (
@@ -43744,14 +43642,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "sCq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "sCs" = (
@@ -43764,6 +43659,9 @@
 /area/engineering/atmos)
 "sCH" = (
 /obj/machinery/medical_kiosk,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "sCJ" = (
@@ -43841,6 +43739,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "sEm" = (
@@ -43858,6 +43759,7 @@
 /area/engineering/storage/tech)
 "sEy" = (
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "sEE" = (
@@ -43894,7 +43796,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "sFl" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -43949,14 +43851,17 @@
 "sGC" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "sGE" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/trimline/red/corner{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/side,
+/turf/open/floor/iron/dark,
 /area/command/bridge)
 "sGG" = (
 /obj/effect/spawner/bundle/moisture_trap,
@@ -44038,6 +43943,13 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"sHR" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "sHS" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -44047,13 +43959,10 @@
 /obj/structure/table,
 /obj/item/surgicaldrill,
 /obj/item/circular_saw,
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/firealarm/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/firealarm/directional/west,
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "sIg" = (
@@ -44125,17 +44034,16 @@
 "sIW" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "sJq" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/cargo/office)
 "sJz" = (
@@ -44148,6 +44056,9 @@
 "sJG" = (
 /obj/machinery/vending/wallmed{
 	pixel_x = -28
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
@@ -44170,7 +44081,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "sKw" = (
 /obj/machinery/camera{
@@ -44186,17 +44097,20 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "sKO" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/public/glass{
 	name = "Bar"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/service/bar)
 "sKY" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_candy,
 /obj/item/kitchen/fork/plastic,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "sLc" = (
@@ -44231,12 +44145,11 @@
 /turf/open/floor/iron,
 /area/maintenance/disposal/incinerator)
 "sLG" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -44260,6 +44173,9 @@
 /area/engineering/atmos)
 "sMF" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "sMU" = (
@@ -44292,10 +44208,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "sNo" = (
+/obj/effect/landmark/start/hangover,
 /obj/structure/chair/wood{
 	dir = 4
 	},
-/obj/effect/landmark/start/hangover,
 /obj/machinery/status_display/evac/directional/west,
 /obj/machinery/light/warm/directional/west,
 /turf/open/floor/wood,
@@ -44304,7 +44220,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44564,18 +44479,10 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/closet/emcloset/anchored,
+/obj/effect/turf_decal/trimline/purple/filled/end{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "sSr" = (
@@ -44647,34 +44554,29 @@
 /turf/open/floor/wood,
 /area/medical/psychology)
 "sTo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=9";
 	location = "8"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "sTR" = (
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "sUb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sUf" = (
@@ -44868,21 +44770,18 @@
 /turf/open/floor/wood,
 /area/maintenance/starboard/aft)
 "sYW" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Entrance";
 	network = list("ss13","engine")
 	},
+/obj/structure/cable,
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/item/radio/intercom/directional/north,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "sZa" = (
@@ -44890,14 +44789,14 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "sZk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/south,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "tab" = (
@@ -44986,6 +44885,11 @@
 "tbm" = (
 /turf/open/floor/iron,
 /area/maintenance/department/engine/atmos)
+"tbA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "tbC" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
@@ -45025,12 +44929,12 @@
 	},
 /area/maintenance/department/science)
 "tcl" = (
-/obj/structure/chair{
-	dir = 4
-	},
 /obj/effect/landmark/start/shaft_miner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/cargo/miningdock)
 "tcr" = (
@@ -45083,26 +44987,23 @@
 /turf/open/floor/plating,
 /area/service/chapel/office)
 "tdM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
 	req_access_txt = "46"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
 "tea" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "teo" = (
@@ -45136,6 +45037,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "tfa" = (
@@ -45150,6 +45054,9 @@
 "tfe" = (
 /obj/effect/landmark/start/clown,
 /obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -45159,9 +45066,6 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/theater)
@@ -45185,6 +45089,14 @@
 	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
+"tge" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "tgq" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/bounty_board/directional/north,
@@ -45259,6 +45171,9 @@
 /area/security/range)
 "tjv" = (
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "tjB" = (
@@ -45276,16 +45191,6 @@
 	network = list("ss13","rd")
 	},
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -45299,14 +45204,11 @@
 /turf/open/floor/iron/dark,
 /area/security/courtroom)
 "tjT" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "tjX" = (
@@ -45332,13 +45234,12 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/pharmacy)
 "tkG" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/closet/emcloset,
 /obj/machinery/firealarm/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tlo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45366,14 +45267,14 @@
 /turf/open/floor/iron,
 /area/security/prison/garden)
 "tlK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "Ian's Quarters";
 	req_access_txt = "57"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/obj/structure/cable,
 /turf/open/floor/iron,
 /area/command/corporate_showroom)
 "tlO" = (
@@ -45506,15 +45407,14 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "toq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/security/brig)
 "tov" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -45673,6 +45573,9 @@
 "ttp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/status_display/evac/directional/south,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "ttw" = (
@@ -45684,14 +45587,8 @@
 	c_tag = "Central Hallway - Bar";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -45700,6 +45597,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "ttG" = (
@@ -45720,16 +45620,13 @@
 	codes_txt = "patrol;next_patrol=6";
 	location = "5"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "tub" = (
@@ -45739,21 +45636,15 @@
 	},
 /obj/item/grenade/chem_grenade/colorful,
 /obj/item/grenade/chem_grenade/glitter,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tug" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
-/area/hallway/secondary/command)
+/area/hallway/primary/fore)
 "tui" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/status_display/ai/directional/west,
@@ -45769,6 +45660,9 @@
 "tuB" = (
 /obj/machinery/light/directional/west,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "tuG" = (
@@ -45834,9 +45728,9 @@
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
 "twq" = (
+/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/west,
-/obj/structure/cable,
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -45862,6 +45756,9 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "txi" = (
@@ -45878,13 +45775,10 @@
 /turf/open/floor/iron/sepia,
 /area/service/chapel/office)
 "txT" = (
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "txU" = (
@@ -45911,6 +45805,12 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/showroomfloor,
 /area/engineering/transit_tube)
+"tyW" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "tzb" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/sign/warning/vacuum/external{
@@ -45964,13 +45864,14 @@
 "tzX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "tzZ" = (
 /obj/machinery/door/airlock/external{
@@ -46019,29 +45920,17 @@
 /turf/open/floor/iron,
 /area/engineering/atmos/experiment_room)
 "tBc" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/destructive_scanner,
-/turf/open/floor/iron,
-/area/hallway/primary/starboard)
-"tBm" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/purple/filled/end{
 	dir = 1
 	},
 /turf/open/floor/iron,
-/area/hallway/primary/aft)
+/area/hallway/primary/starboard)
+"tBm" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "tBu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -46084,13 +45973,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "tBU" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/delivery/white{
 	color = "#52B4E9"
 	},
@@ -46114,6 +45996,7 @@
 "tCH" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/bounty_board/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "tCY" = (
@@ -46133,12 +46016,14 @@
 "tDa" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_corner{
+	dir = 4
+	},
 /area/security/brig)
 "tDm" = (
 /obj/docking_port/stationary/random{
@@ -46157,8 +46042,7 @@
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
@@ -46216,7 +46100,7 @@
 	name = "Security Blast Door"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tFJ" = (
 /obj/structure/closet/crate/hydroponics,
@@ -46258,11 +46142,10 @@
 /area/maintenance/central/secondary)
 "tGv" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/machinery/vending/coffee,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "tGA" = (
@@ -46398,18 +46281,16 @@
 	dir = 4
 	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/white,
 /area/science/research)
 "tJM" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "tKJ" = (
 /obj/machinery/door/window/northright{
 	name = "Containment Pen #7";
@@ -46433,12 +46314,12 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "tLu" = (
+/obj/structure/cable,
+/obj/machinery/duct,
 /obj/machinery/door/airlock/maintenance{
 	name = "Kitchen Maintenance";
 	req_access_txt = "28"
 	},
-/obj/structure/cable,
-/obj/machinery/duct,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/service)
@@ -46446,31 +46327,22 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "tLN" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/structure/table,
 /obj/item/healthanalyzer,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "tLO" = (
@@ -46492,16 +46364,10 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "tMh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "tMi" = (
@@ -46513,19 +46379,15 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "tMl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tMs" = (
 /obj/structure/table,
@@ -46548,26 +46410,23 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "tMY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "tNc" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/item/beacon,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "tNo" = (
@@ -46585,16 +46444,13 @@
 /turf/open/floor/plating,
 /area/security/execution/education)
 "tOo" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "tOp" = (
@@ -46632,14 +46488,14 @@
 /turf/closed/wall/r_wall,
 /area/command/heads_quarters/hos)
 "tPV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
 	req_access_txt = "19"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
@@ -46652,6 +46508,9 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/status_display/evac/directional/west,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "tQB" = (
@@ -46659,11 +46518,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/iron,
 /area/security/brig)
 "tQL" = (
 /obj/structure/chair{
@@ -46672,13 +46530,14 @@
 /turf/open/floor/iron/grimy,
 /area/security/brig)
 "tQM" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/white,
 /area/science/research)
 "tQN" = (
@@ -46697,6 +46556,7 @@
 	},
 /obj/item/storage/firstaid/regular,
 /obj/item/storage/firstaid/regular,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "tRt" = (
@@ -46722,14 +46582,10 @@
 /turf/open/floor/iron/airless,
 /area/science/test_area)
 "tRI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "tRR" = (
 /turf/closed/wall/r_wall,
@@ -46740,9 +46596,10 @@
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "tSy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/showroomfloor,
-/area/science/lab)
+/obj/item/radio/intercom/directional/north,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "tSE" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -46768,6 +46625,9 @@
 "tTF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "tTG" = (
@@ -46791,24 +46651,24 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "tUb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/light/directional/east,
 /obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "tUz" = (
 /obj/structure/table,
@@ -46918,16 +46778,18 @@
 /area/service/library)
 "tXh" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "tXs" = (
 /obj/machinery/airalarm/directional/east,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
+"tXF" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -46955,7 +46817,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/trimline/red/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 1
 	},
 /turf/open/floor/iron/dark/corner{
@@ -47023,16 +46888,13 @@
 	dir = 1;
 	network = list("ss13","rd")
 	},
+/obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "tZF" = (
 /obj/machinery/telecomms/server/presets/science,
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/trimline/purple/filled/end{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
@@ -47049,7 +46911,7 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "tZX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -47208,8 +47070,8 @@
 /turf/open/floor/iron,
 /area/cargo/office)
 "udg" = (
-/obj/machinery/light/directional/west,
 /obj/structure/cable,
+/obj/machinery/light/directional/west,
 /turf/open/floor/mineral/plastitanium{
 	name = "black plastitanium floor"
 	},
@@ -47257,13 +47119,12 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "ueS" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /obj/effect/landmark/start/geneticist,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
@@ -47299,22 +47160,19 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "uft" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=4";
-	location = "3"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=4";
+	location = "3"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "ufw" = (
@@ -47325,20 +47183,11 @@
 /turf/open/floor/iron/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "ufC" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
 /obj/structure/table/glass,
 /obj/item/experi_scanner,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "ufZ" = (
@@ -47383,15 +47232,12 @@
 /area/maintenance/department/cargo)
 "ugr" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "ugR" = (
 /obj/effect/turf_decal/stripes/line{
@@ -47405,6 +47251,9 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/depsec/supply,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "uhj" = (
@@ -47439,6 +47288,13 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/service/library)
+"uim" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "uis" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/visible,
 /turf/closed/wall/r_wall,
@@ -47459,6 +47315,9 @@
 /area/maintenance/department/medical)
 "ujJ" = (
 /obj/effect/landmark/start/depsec/supply,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/office)
 "ujS" = (
@@ -47506,6 +47365,9 @@
 	},
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/tank_holder/extinguisher,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "ukS" = (
@@ -47616,11 +47478,8 @@
 /turf/open/floor/iron,
 /area/hallway/secondary/entry)
 "unC" = (
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -47638,17 +47497,14 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "uoh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/security/courtroom)
 "uoo" = (
@@ -47697,10 +47553,10 @@
 	},
 /area/maintenance/aft)
 "uoC" = (
-/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/disposal/bin,
 /obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron/dark,
 /area/service/kitchen)
@@ -47709,6 +47565,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/experiment_room)
+"uoZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "upg" = (
 /obj/structure/closet/crate{
 	name = "Art Crate"
@@ -47752,6 +47615,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "uqy" = (
@@ -47805,6 +47669,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/beacon,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "usb" = (
@@ -47829,6 +47696,18 @@
 /obj/machinery/smartfridge,
 /turf/closed/wall,
 /area/service/hydroponics)
+"usL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/brown/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/exit)
 "usV" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -47840,13 +47719,11 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "ute" = (
 /obj/structure/table/reinforced,
@@ -48095,11 +47972,11 @@
 /turf/open/floor/engine,
 /area/engineering/supermatter)
 "uyi" = (
+/obj/effect/landmark/start/janitor,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/landmark/start/janitor,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "uyr" = (
@@ -48134,6 +48011,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uze" = (
@@ -48172,6 +48052,21 @@
 	},
 /turf/open/floor/iron/dark,
 /area/security/office)
+"uAq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	name = "medical sorting disposal pipe";
+	sortType = 9
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "uAB" = (
 /obj/effect/mapping_helpers/ianbirthday,
 /turf/open/floor/carpet/royalblue,
@@ -48215,7 +48110,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "uBH" = (
 /turf/open/floor/engine/air,
@@ -48268,19 +48163,23 @@
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "uCY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 8
+	},
 /area/security/brig)
 "uDi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/paramedic,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "uDy" = (
@@ -48294,14 +48193,8 @@
 /area/engineering/main)
 "uDD" = (
 /obj/machinery/telecomms/server/presets/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/end{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
@@ -48340,12 +48233,8 @@
 /area/hallway/secondary/entry)
 "uEy" = (
 /obj/machinery/telecomms/server/presets/medical,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/end{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/iron/white/telecomms,
 /area/tcommsat/server)
@@ -48371,16 +48260,9 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "uGa" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48420,20 +48302,19 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "uHt" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "uHJ" = (
@@ -48454,12 +48335,21 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"uIq" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "uIs" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "uIC" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "uIG" = (
@@ -48479,6 +48369,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/science,
 /obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "uJa" = (
@@ -48603,17 +48496,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "uLp" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Primary Tool Storage"
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/public/glass{
+	name = "Primary Tool Storage"
+	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/commons/storage/primary)
 "uLv" = (
@@ -48679,16 +48575,11 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "uMx" = (
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
-/area/hallway/primary/port)
+/area/hallway/primary/fore)
 "uMG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
@@ -48704,15 +48595,12 @@
 	},
 /area/maintenance/department/cargo)
 "uMR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "uMX" = (
 /obj/structure/chair/stool{
@@ -48843,6 +48731,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/science/test_area)
+"uQz" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/command)
 "uQL" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -48906,7 +48799,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "uSi" = (
 /obj/effect/turf_decal/stripes/line,
@@ -48919,6 +48812,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "uSl" = (
@@ -48929,15 +48825,11 @@
 /turf/open/floor/wood,
 /area/commons/dorms)
 "uSr" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "uSv" = (
 /obj/structure/closet/firecloset,
@@ -48952,14 +48844,8 @@
 /turf/open/floor/iron/dark,
 /area/security/range)
 "uSV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
@@ -49030,10 +48916,7 @@
 /turf/open/floor/iron/dark,
 /area/engineering/atmos/experiment_room)
 "uUj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -49108,6 +48991,7 @@
 /area/maintenance/central/secondary)
 "uVG" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "uVR" = (
@@ -49198,21 +49082,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "uYI" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "uZe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -49235,6 +49113,7 @@
 /obj/item/paper_bin{
 	pixel_y = 4
 	},
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "vac" = (
@@ -49277,6 +49156,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
+"vbt" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "vbA" = (
 /turf/open/floor/plating,
 /area/security/brig)
@@ -49378,15 +49263,14 @@
 /obj/machinery/computer/security/mining{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
 /obj/machinery/camera{
 	c_tag = "Command - Aft Bridge Windows";
 	dir = 1
 	},
 /obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "veG" = (
@@ -49428,12 +49312,8 @@
 	},
 /area/service/bar)
 "vfA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "vfC" = (
 /obj/structure/cable,
@@ -49443,17 +49323,11 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "vfH" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/primary/central)
@@ -49494,6 +49368,9 @@
 /area/maintenance/central/secondary)
 "vgr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -49547,6 +49424,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/corner,
 /turf/open/floor/iron,
 /area/cargo/office)
 "vhA" = (
@@ -49583,6 +49461,7 @@
 	},
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/gloves/color/latex,
+/obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "vhT" = (
@@ -49616,18 +49495,12 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "vio" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "vip" = (
@@ -49684,9 +49557,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
+/obj/machinery/status_display/evac/directional/south,
 /turf/open/floor/iron,
 /area/service/kitchen)
 "vjo" = (
@@ -49697,10 +49568,8 @@
 /turf/open/floor/wood,
 /area/command/heads_quarters/hos)
 "vjz" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /obj/machinery/piratepad/civilian,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "vjI" = (
@@ -49709,6 +49578,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/depsec/medical,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vjM" = (
@@ -49824,9 +49696,8 @@
 /obj/machinery/computer/shuttle/labor{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -49848,6 +49719,13 @@
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
+"voF" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "voK" = (
 /obj/structure/table,
 /obj/item/clothing/ears/earmuffs{
@@ -49858,19 +49736,15 @@
 	pixel_x = -3;
 	pixel_y = -2
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/item/hand_labeler{
 	pixel_y = 8
 	},
 /obj/item/clothing/glasses/sunglasses{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
@@ -49880,13 +49754,15 @@
 	name = "Treatment Center";
 	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
+"voZ" = (
+/obj/effect/turf_decal/trimline/brown/filled/warning{
+	dir = 4
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/cargo/office)
 "vpd" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -49894,22 +49770,21 @@
 /turf/open/floor/iron/dark,
 /area/security/office)
 "vpe" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Service Hall";
 	req_one_access_txt = "22;25;26;28;35;37;38;46"
 	},
-/obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/central)
 "vpz" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "vpE" = (
@@ -49926,14 +49801,8 @@
 /turf/closed/wall,
 /area/maintenance/disposal)
 "vpR" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/light/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "vqp" = (
@@ -49986,13 +49855,12 @@
 /turf/open/floor/iron,
 /area/medical/storage)
 "vqT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/security/brig)
 "vrj" = (
 /obj/machinery/firealarm/directional/north,
@@ -50095,16 +49963,15 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "vug" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/security/brig)
 "vuA" = (
 /obj/structure/disposalpipe/segment{
@@ -50113,7 +49980,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "vuE" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -50167,6 +50034,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/security/execution/education)
+"vvM" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/command)
 "vwd" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron,
@@ -50223,6 +50096,13 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/captain/private)
+"vyl" = (
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/central)
 "vyI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/iron,
@@ -50246,20 +50126,14 @@
 "vyP" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/item/clothing/under/rank/security/warden/grey,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Security - Warden's Office";
 	dir = 4
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "vyQ" = (
@@ -50318,16 +50192,7 @@
 	name = "Medbay Delivery";
 	req_one_access_txt = "5"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white/textured,
 /area/medical/cryo)
 "vAS" = (
@@ -50369,10 +50234,7 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "vCa" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
 /turf/open/floor/iron/showroomfloor,
@@ -50385,8 +50247,8 @@
 /area/service/chapel)
 "vCo" = (
 /obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/duct,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/smooth_large,
 /area/hallway/secondary/service)
 "vCp" = (
@@ -50412,12 +50274,6 @@
 /turf/open/floor/iron/showroomfloor,
 /area/medical/virology)
 "vCT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
@@ -50427,7 +50283,10 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "vDe" = (
 /obj/machinery/conveyor{
@@ -50445,19 +50304,13 @@
 	name = "hydroponics sorting disposal pipe";
 	sortType = 21
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "vDn" = (
@@ -50477,6 +50330,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/dark,
 /area/cargo/storage)
+"vEl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "vEr" = (
 /mob/living/simple_animal/bot/mulebot{
 	home_destination = "QM #1";
@@ -50528,6 +50388,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "vFK" = (
@@ -50552,6 +50415,15 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"vGu" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "vGC" = (
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/iron,
@@ -50676,15 +50548,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "vKr" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/green/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner{
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/medical/virology)
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "vKP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50703,21 +50571,25 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/showroomfloor,
 /area/science/robotics/lab)
+"vLj" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "vLq" = (
 /turf/closed/wall/r_wall,
 /area/security/warden)
 "vLr" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/structure/cable,
 /obj/machinery/newscaster/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/surgery)
 "vLz" = (
@@ -50726,11 +50598,7 @@
 /turf/open/floor/carpet/orange,
 /area/commons/vacant_room/office)
 "vLJ" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/end{
 	dir = 8
 	},
 /turf/open/floor/iron/white/telecomms,
@@ -50741,16 +50609,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/command/heads_quarters/ce)
-"vMB" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/security/brig)
 "vNd" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -50764,6 +50622,9 @@
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/science/research)
 "vNP" = (
@@ -50787,12 +50648,12 @@
 /turf/open/floor/wood,
 /area/service/bar)
 "vOh" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "vOi" = (
@@ -50821,6 +50682,9 @@
 /area/ai_monitored/security/armory)
 "vOq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "vOs" = (
@@ -50898,6 +50762,10 @@
 	},
 /turf/open/floor/iron,
 /area/science/mixing)
+"vPs" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/medbay/lobby)
 "vPt" = (
 /obj/structure/window{
 	dir = 4
@@ -50906,11 +50774,11 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "vPx" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/table,
 /obj/machinery/microwave{
 	pixel_y = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "vPQ" = (
@@ -50919,6 +50787,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
 	},
 /turf/open/floor/iron/white,
 /area/science/research)
@@ -50955,14 +50826,20 @@
 /obj/structure/bookcase,
 /turf/open/floor/iron,
 /area/security/prison/rec)
-"vRW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
+"vRP" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/turf/open/floor/iron/white,
+/area/medical/patients_rooms)
+"vRW" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
+	},
 /area/security/brig)
 "vRY" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -51017,11 +50894,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "vTq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/vending/medical,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "vTt" = (
@@ -51081,6 +50964,13 @@
 /obj/structure/closet/secure_closet/security/sec,
 /turf/open/floor/iron/dark,
 /area/security/office)
+"vTW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "vUe" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -51188,26 +51078,20 @@
 /area/service/hydroponics/garden)
 "vXB" = (
 /obj/machinery/light/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/sign/warning/pods{
 	pixel_y = 30
 	},
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "vYb" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "vYe" = (
@@ -51302,6 +51186,12 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/explab)
+"vZp" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "vZu" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -51321,15 +51211,24 @@
 "was" = (
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"waQ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"wat" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
+"waQ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/security/brig)
 "waS" = (
 /obj/structure/closet/toolcloset,
@@ -51444,11 +51343,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "wdQ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/lobby)
 "wdU" = (
@@ -51485,6 +51381,10 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/electrical)
+"weL" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "weQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille,
@@ -51504,19 +51404,31 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/turf_decal/trimline/red/corner{
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/red/filled/corner{
 	dir = 4
 	},
 /turf/open/floor/iron/dark/corner{
 	dir = 4
 	},
 /area/hallway/secondary/command)
+"wfx" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/white,
+/area/medical/medbay/central)
 "wfz" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/status_display/evac/directional/east,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wfN" = (
@@ -51529,8 +51441,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
-/turf/open/floor/iron,
+/turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
+"wfW" = (
+/obj/structure/flora/grass/green,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "wfY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -51595,6 +51514,7 @@
 /area/command/heads_quarters/hos)
 "wgV" = (
 /obj/machinery/dna_scannernew,
+/obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron/showroomfloor,
 /area/science/genetics)
 "wha" = (
@@ -51711,6 +51631,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "wjx" = (
@@ -51722,6 +51643,9 @@
 "wjI" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/light/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "wjL" = (
@@ -51761,20 +51685,22 @@
 /turf/open/floor/iron,
 /area/cargo/warehouse)
 "wkU" = (
-/obj/effect/turf_decal/tile/red{
+/obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
 	},
-/obj/item/radio/intercom/directional/west,
-/turf/open/floor/iron,
 /area/security/brig)
 "wkZ" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "wlc" = (
@@ -51786,13 +51712,9 @@
 /area/hallway/secondary/entry)
 "wld" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "wlg" = (
@@ -51826,11 +51748,10 @@
 	req_access_txt = "63";
 	specialfunctions = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "wln" = (
@@ -52001,18 +51922,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine/atmos)
 "wol" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
+/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
-/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "woq" = (
@@ -52028,24 +51946,21 @@
 	},
 /area/holodeck/rec_center)
 "woI" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/evac/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "wpe" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "wpu" = (
@@ -52066,8 +51981,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "wqc" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "wql" = (
@@ -52083,6 +52000,10 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/security/prison/work)
+"wqw" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/grass,
+/area/service/hydroponics)
 "wqD" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/machinery/firealarm/directional/west,
@@ -52142,6 +52063,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/west,
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "wsx" = (
@@ -52182,14 +52106,11 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "wtq" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/light/directional/west,
 /obj/machinery/airalarm/directional/west,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "wtA" = (
@@ -52206,7 +52127,7 @@
 /area/science/xenobiology)
 "wtI" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark/smooth_large,
 /area/security/brig)
 "wtJ" = (
 /obj/structure/table,
@@ -52229,6 +52150,13 @@
 /obj/effect/spawner/bundle/costume/nyangirl,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"wuX" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "wuZ" = (
 /obj/machinery/conveyor{
 	id = "cargodelivery2";
@@ -52263,6 +52191,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wvC" = (
@@ -52291,36 +52220,34 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wwd" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
 /obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/iron,
-/area/engineering/atmos)
-"wwF" = (
 /obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/engineering/atmos)
+"wwF" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/visible/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "wwI" = (
@@ -52353,18 +52280,12 @@
 /area/maintenance/starboard/aft)
 "wxy" = (
 /obj/machinery/stasis,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /obj/machinery/firealarm/directional/west,
 /obj/machinery/light/cold/directional/west,
 /obj/machinery/defibrillator_mount/directional/south,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "wxA" = (
@@ -52416,12 +52337,8 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "wyT" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
@@ -52494,14 +52411,18 @@
 /turf/open/floor/plating,
 /area/engineering/atmos/experiment_room)
 "wzS" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock/maintenance{
 	name = "Law Office Maintenance";
 	req_access_txt = "38"
 	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"wzW" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/iron/showroomfloor,
+/area/science/xenobiology)
 "wzY" = (
 /obj/machinery/door/airlock/research{
 	name = "Kill Chamber";
@@ -52550,6 +52471,9 @@
 /area/hallway/primary/starboard)
 "wAI" = (
 /obj/effect/spawner/randomcolavend,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "wAX" = (
@@ -52622,22 +52546,16 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "wDV" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/item/radio/intercom/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "wDX" = (
+/obj/structure/cable,
 /obj/machinery/door/airlock{
 	name = "Service Hall";
 	req_one_access_txt = "22;25;26;28;35;37;38;46"
 	},
-/obj/structure/cable,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -52691,14 +52609,11 @@
 /obj/machinery/computer/monitor{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/item/storage/secure/safe/caps_spare{
 	pixel_x = -27
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
 	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
@@ -52744,6 +52659,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "wGz" = (
@@ -52778,6 +52696,9 @@
 /obj/machinery/bounty_board/directional/east,
 /obj/effect/landmark/start/depsec/medical,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wHR" = (
@@ -52889,16 +52810,12 @@
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
 "wLg" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "wLh" = (
@@ -52929,16 +52846,13 @@
 /area/maintenance/port)
 "wLM" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/computer/security/telescreen/entertainment/directional/north,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "wLS" = (
 /obj/structure/chair{
@@ -53002,36 +52916,32 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wNM" = (
+/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/west,
 /obj/machinery/camera{
 	c_tag = "Service - Hydrophonics";
 	dir = 4
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/showroomfloor,
 /area/service/hydroponics)
 "wNN" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "wNX" = (
+/obj/structure/girder/reinforced,
+/obj/structure/lattice,
 /obj/structure/grille,
-/turf/closed/wall/r_wall,
+/turf/open/space/basic,
 /area/space/nearstation)
 "wOq" = (
 /obj/structure/sign/warning/radiation,
@@ -53042,11 +52952,14 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/central/secondary)
 "wOF" = (
+/obj/structure/cable,
 /obj/structure/window{
 	dir = 4
 	},
-/obj/structure/cable,
 /obj/machinery/power/apc/auto_name/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "wOX" = (
@@ -53089,22 +53002,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "wQD" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/engineering/lobby)
 "wQR" = (
@@ -53117,6 +53026,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/newscaster/directional/east,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "wQY" = (
@@ -53179,11 +53091,8 @@
 /turf/open/floor/iron/white,
 /area/medical/virology)
 "wRP" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line,
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "wSc" = (
@@ -53192,6 +53101,15 @@
 	},
 /turf/open/floor/iron,
 /area/cargo/office)
+"wTs" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "wTw" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -53202,17 +53120,13 @@
 /turf/closed/wall/r_wall,
 /area/engineering/atmos)
 "wTV" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/light/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "wTW" = (
@@ -53233,6 +53147,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/engineering/atmos/experiment_room)
+"wUq" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "wUr" = (
 /obj/machinery/camera{
 	c_tag = "Security - Firing Range";
@@ -53274,24 +53198,20 @@
 /turf/open/floor/iron,
 /area/commons/dorms)
 "wUU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/table,
 /obj/item/storage/bag/tray{
 	pixel_y = 5
 	},
 /obj/effect/spawner/lootdrop/donkpockets,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/cafeteria,
 /area/service/kitchen)
 "wVv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/execution/transfer)
 "wVI" = (
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -53301,6 +53221,10 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Recovery Room A"
 	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "wWm" = (
@@ -53402,6 +53326,9 @@
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/qm)
 "wYZ" = (
@@ -53410,16 +53337,10 @@
 /area/science/robotics/lab)
 "wZl" = (
 /obj/machinery/light/directional/south,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "wZs" = (
@@ -53434,6 +53355,15 @@
 "wZN" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
+"xag" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "ianroomlockdown";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/command/corporate_showroom)
 "xaD" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
@@ -53444,24 +53374,21 @@
 /turf/open/floor/iron/cafeteria,
 /area/service/theater)
 "xaO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/turf/open/floor/iron,
-/area/security/brig)
-"xaZ" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark/smooth_edge{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown,
+/area/security/brig)
+"xaZ" = (
 /obj/item/radio/intercom/directional/west,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "xbh" = (
@@ -53484,6 +53411,9 @@
 "xbp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/light/cold/directional/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/white,
 /area/medical/patients_rooms)
 "xbq" = (
@@ -53515,12 +53445,11 @@
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "xbP" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/cryo_cell{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron/white/textured,
 /area/medical/cryo)
@@ -53626,7 +53555,7 @@
 	name = "Evidence Closet"
 	},
 /obj/item/poster/random_contraband,
-/turf/open/floor/iron,
+/turf/open/floor/iron/dark,
 /area/security/brig)
 "xdY" = (
 /obj/machinery/door/airlock/maintenance{
@@ -53673,6 +53602,10 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/grass,
 /area/science/genetics)
+"xfm" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/iron/white,
+/area/medical/storage)
 "xfy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
@@ -53710,11 +53643,11 @@
 /turf/open/floor/iron,
 /area/security/prison)
 "xfX" = (
-/obj/effect/turf_decal/stripes/box,
-/obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/box,
+/obj/machinery/disposal/bin,
 /turf/open/floor/iron/dark,
 /area/service/hydroponics)
 "xgg" = (
@@ -53755,12 +53688,11 @@
 /turf/open/floor/engine,
 /area/engineering/main)
 "xhd" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/light/directional/south,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 1
+	},
 /area/security/brig)
 "xhf" = (
 /obj/machinery/duct,
@@ -53797,10 +53729,6 @@
 /area/command/bridge)
 "xhM" = (
 /obj/machinery/light/directional/east,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/xenobiology)
 "xie" = (
@@ -53870,13 +53798,10 @@
 /turf/open/floor/iron/freezer,
 /area/commons/toilet)
 "xkn" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/machinery/duct,
 /turf/open/floor/iron/white,
 /area/medical/treatment_center)
 "xku" = (
@@ -53947,14 +53872,10 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xmh" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/machinery/firealarm/directional/east,
+/obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "xml" = (
@@ -53973,7 +53894,6 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "xmG" = (
-/obj/effect/turf_decal/delivery,
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -53981,6 +53901,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/hallway/secondary/command)
 "xmI" = (
@@ -54062,7 +53983,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/turf/open/floor/plating,
 /area/security/brig)
 "xoJ" = (
 /obj/effect/turf_decal/bot,
@@ -54078,6 +53999,9 @@
 /area/science/research)
 "xoR" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "xoT" = (
@@ -54103,6 +54027,7 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
+/obj/effect/turf_decal/tile/blue/full,
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "xoX" = (
@@ -54177,8 +54102,8 @@
 /area/medical/treatment_center)
 "xqs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/chair/stool/bar/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/chair/stool/bar/directional/north,
 /turf/open/floor/wood,
 /area/service/bar)
 "xqx" = (
@@ -54237,6 +54162,7 @@
 /obj/item/clothing/shoes/wheelys/rollerskates{
 	pixel_y = 5
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/cargo/storage)
 "xrv" = (
@@ -54280,6 +54206,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/extinguisher_cabinet/directional/east,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/white,
 /area/medical/storage)
 "xsG" = (
@@ -54321,13 +54250,12 @@
 /area/space)
 "xtd" = (
 /obj/machinery/light/directional/west,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/iron/dark/smooth_edge{
+	dir = 4
 	},
-/turf/open/floor/iron,
 /area/security/brig)
 "xtg" = (
 /turf/closed/wall/r_wall,
@@ -54445,15 +54373,12 @@
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "xxg" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "xxu" = (
 /obj/machinery/door/airlock/maintenance,
@@ -54601,13 +54526,10 @@
 	},
 /area/maintenance/department/science)
 "xAy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/chair{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
 /turf/open/floor/iron,
@@ -54619,6 +54541,7 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/medical/medbay/central)
 "xAF" = (
@@ -54685,6 +54608,9 @@
 "xCc" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "xCh" = (
@@ -54692,6 +54618,9 @@
 /obj/machinery/newscaster/directional/east,
 /obj/effect/turf_decal/loading_area,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "xCk" = (
@@ -54787,22 +54716,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/landmark/start/hangover,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
 	},
 /turf/open/floor/iron,
 /area/hallway/secondary/exit)
 "xDH" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
@@ -54856,11 +54778,14 @@
 /turf/closed/wall,
 /area/cargo/sorting)
 "xFv" = (
-/obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
 /obj/effect/landmark/start/assistant,
+/obj/effect/turf_decal/bot,
 /obj/structure/chair/stool/bar{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 4
 	},
 /turf/open/floor/iron,
 /area/service/kitchen)
@@ -54912,6 +54837,12 @@
 	},
 /turf/open/floor/iron,
 /area/service/hydroponics/garden)
+"xGJ" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/starboard)
 "xGL" = (
 /obj/structure/table/reinforced,
 /obj/item/pen,
@@ -54973,18 +54904,18 @@
 	c_tag = "Cargo - Lobby";
 	network = list("ss13","qm")
 	},
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/cargo/office)
 "xIU" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "xJa" = (
@@ -55057,6 +54988,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
+"xKf" = (
+/obj/machinery/bounty_board/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "xKk" = (
 /obj/structure/railing{
 	dir = 10
@@ -55082,6 +55020,9 @@
 /turf/open/floor/iron,
 /area/service/kitchen)
 "xLh" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -55153,6 +55094,9 @@
 	},
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "xNv" = (
@@ -55175,6 +55119,9 @@
 /area/maintenance/central/secondary)
 "xNR" = (
 /obj/structure/extinguisher_cabinet/directional/north,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/cargo/storage)
 "xOh" = (
@@ -55186,10 +55133,8 @@
 	},
 /area/science/test_area)
 "xOt" = (
-/obj/machinery/status_display/evac{
-	pixel_x = -32
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "xOE" = (
@@ -55255,14 +55200,8 @@
 /turf/closed/wall,
 /area/maintenance/central/secondary)
 "xQi" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/effect/turf_decal/trimline/brown/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "xQk" = (
@@ -55457,6 +55396,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white,
 /area/science/mixing)
+"xUf" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/fore)
 "xUE" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/flora/ausbushes/brflowers,
@@ -55515,14 +55461,10 @@
 /obj/machinery/recharger{
 	pixel_x = 6
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
 /obj/structure/cable,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 6
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/security/warden)
 "xVH" = (
@@ -55561,6 +55503,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "xWq" = (
+/obj/structure/cable,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -55572,7 +55515,6 @@
 	pixel_x = -10;
 	pixel_y = 22
 	},
-/obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "xWB" = (
@@ -55599,26 +55541,24 @@
 /turf/open/floor/plating,
 /area/command/heads_quarters/ce)
 "xXd" = (
-/obj/effect/turf_decal/tile/brown{
+/obj/effect/spawner/randomsnackvend,
+/obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/spawner/randomsnackvend,
 /turf/open/floor/iron,
 /area/hallway/primary/central)
 "xXf" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
+"xXj" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/chemistry)
 "xXk" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Emitter Room";
@@ -55636,12 +55576,12 @@
 /turf/open/floor/plating,
 /area/engineering/main)
 "xXA" = (
+/obj/structure/disposalpipe/trunk,
 /obj/structure/window{
 	dir = 4
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/stripes/box,
-/obj/structure/disposalpipe/trunk,
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
@@ -55659,26 +55599,23 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/command)
 "xXW" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/structure/cable,
 /obj/structure/cable/layer3,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
 /turf/open/floor/iron/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "xXZ" = (
+/obj/effect/landmark/start/janitor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/effect/landmark/start/janitor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/service/janitor)
 "xYg" = (
@@ -55709,6 +55646,9 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/port)
 "xYT" = (
@@ -55716,13 +55656,9 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xYU" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/iron,
 /area/hallway/primary/starboard)
 "xZg" = (
@@ -55784,6 +55720,9 @@
 /area/service/hydroponics/garden)
 "yay" = (
 /obj/machinery/newscaster/directional/south,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "yaC" = (
@@ -55806,7 +55745,6 @@
 /turf/open/floor/iron,
 /area/engineering/atmos)
 "yaO" = (
-/obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
@@ -55836,45 +55774,49 @@
 /turf/open/floor/iron,
 /area/construction/mining/aux_base)
 "ybg" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
 /obj/effect/turf_decal/siding/blue/corner,
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/aft)
 "ybo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
 /area/security/brig)
+"ybq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/white,
+/area/medical/storage)
+"ybS" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner,
+/turf/open/floor/iron/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ycp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/engineering/gravity_generator)
 "ycr" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
+/obj/effect/turf_decal/trimline/neutral/filled/end{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "ycQ" = (
@@ -55885,18 +55827,19 @@
 "ycS" = (
 /obj/structure/cable,
 /obj/machinery/duct,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/science/lab)
 "ycU" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/airalarm/directional/north,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
 	},
-/turf/open/floor/iron,
+/obj/effect/spawner/randomsnackvend,
+/turf/open/floor/iron/dark/smooth_edge,
 /area/security/brig)
 "ydd" = (
 /obj/effect/landmark/blobstart,
@@ -55908,6 +55851,11 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"ydX" = (
+/obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/turf/open/floor/iron,
+/area/hallway/secondary/command)
 "yea" = (
 /obj/effect/spawner/randomsnackvend,
 /obj/machinery/status_display/evac/directional/north,
@@ -56034,17 +55982,16 @@
 	pixel_x = 9;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron/dark/telecomms,
 /area/tcommsat/server)
 "yik" = (
+/obj/effect/landmark/start/cargo_technician,
 /obj/structure/chair/office{
 	dir = 8
 	},
-/obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/iron,
 /area/cargo/sorting)
 "yin" = (
@@ -56086,13 +56033,12 @@
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	name = "cmo sorting disposal pipe";
+	sortType = 10
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron,
 /area/hallway/primary/fore)
 "yjB" = (
@@ -56112,12 +56058,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical)
 "yjS" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -56136,16 +56076,13 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "ykw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
 /obj/machinery/computer/prisoner/management{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /obj/machinery/newscaster/directional/west,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 9
+	},
 /turf/open/floor/iron/dark,
 /area/command/bridge)
 "ykO" = (
@@ -56162,10 +56099,18 @@
 /turf/open/floor/iron/grimy,
 /area/maintenance/central/secondary)
 "ylL" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/open/floor/plating,
-/area/maintenance/central)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/hallway/primary/port)
 "ylP" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -67905,9 +67850,9 @@ xeN
 xeN
 xeN
 xzK
-saj
+bYt
 xzK
-cXC
+xeN
 bYt
 bYt
 bYt
@@ -68148,18 +68093,18 @@ xeN
 xzK
 xzK
 xeN
-kru
-kru
-kru
+xzK
+xzK
+xzK
 xeN
 xeN
-kru
-kru
-kru
-kru
-kru
-kru
-kru
+xzK
+xzK
+xzK
+xzK
+xzK
+xzK
+xzK
 xeN
 xzK
 bYt
@@ -68189,10 +68134,10 @@ xeN
 xeN
 xeN
 bYt
-cXC
-cXC
-cXC
-cXC
+xeN
+xeN
+xeN
+xeN
 xzK
 xzK
 xzK
@@ -68676,8 +68621,8 @@ xzK
 xzK
 bYt
 jWW
-kru
-kru
+xzK
+xzK
 xeN
 dAv
 aok
@@ -69133,7 +69078,7 @@ eIK
 pGt
 uSr
 vOk
-nMY
+vfA
 dqT
 feT
 gzj
@@ -69391,7 +69336,7 @@ dyH
 pHz
 vOk
 rYs
-kQn
+rYs
 omn
 bCr
 ptK
@@ -69731,13 +69676,13 @@ xzK
 xzK
 xzK
 xzK
-utN
+bYt
 ijM
 eNt
 doY
 lKv
 ijM
-cDL
+bYt
 xeN
 xzK
 xzK
@@ -69988,13 +69933,13 @@ xzK
 xzK
 xzK
 xzK
-utN
+bYt
 ijM
 qtc
 doY
 lYr
 ijM
-cDL
+bYt
 xeN
 xzK
 xzK
@@ -70673,11 +70618,11 @@ gqe
 uze
 uze
 vvL
-haf
+iCv
 rIC
 sca
 dIK
-vMB
+waQ
 oVl
 tjp
 uSR
@@ -70932,8 +70877,8 @@ aBO
 vmS
 vmS
 aZq
-csg
-sca
+gPz
+bCN
 gJK
 eDp
 mnx
@@ -70967,9 +70912,9 @@ bYt
 bYt
 bYt
 xeN
-cXC
-cXC
-cXC
+xeN
+xeN
+xeN
 xzK
 bYt
 bYt
@@ -71189,8 +71134,8 @@ iKm
 kQe
 vmS
 lRM
-csg
-sca
+gPz
+bCN
 tQB
 eDp
 eDp
@@ -71447,8 +71392,8 @@ dMi
 vmS
 dNh
 ozY
-rIC
-rBy
+sca
+rTi
 neG
 ihH
 stR
@@ -71705,7 +71650,7 @@ rUY
 rUY
 rUY
 jKW
-rBy
+rTi
 qxT
 rfE
 bnc
@@ -72219,7 +72164,7 @@ nHP
 jQt
 flR
 ugr
-rBy
+rTi
 cUp
 fWp
 lCB
@@ -72476,7 +72421,7 @@ nHP
 lUf
 rUY
 wLM
-nUj
+xhd
 tHg
 tHg
 tHg
@@ -72732,8 +72677,8 @@ dDw
 nHP
 dOJ
 rUY
-rVS
-rBy
+ugr
+rTi
 wHR
 pML
 sSL
@@ -73246,8 +73191,8 @@ dHi
 tFB
 nIC
 ldB
-rVS
-rBy
+ugr
+rTi
 wHR
 reO
 lZK
@@ -73499,12 +73444,12 @@ qzR
 gSU
 qzR
 qzR
-hXl
+amz
 eGC
 noT
 hXl
-rVS
-rBy
+ugr
+rTi
 wHR
 bHd
 lml
@@ -73760,8 +73705,8 @@ sFi
 cqe
 lvN
 goV
-rVS
-rBy
+ugr
+rTi
 wHR
 bHd
 lml
@@ -74275,7 +74220,7 @@ xzK
 xzK
 gqD
 dys
-rBy
+rTi
 wHR
 reO
 qZL
@@ -74532,7 +74477,7 @@ xzK
 xzK
 gqD
 vCT
-rBy
+rTi
 wHR
 iMe
 eoq
@@ -75302,7 +75247,7 @@ kkY
 vbA
 bgm
 drM
-rVS
+ugr
 cNa
 kih
 vRW
@@ -75312,7 +75257,7 @@ vRW
 vRW
 vRW
 vRW
-eKU
+rSS
 bxL
 vRW
 vRW
@@ -75323,7 +75268,7 @@ vRW
 vug
 vRW
 vRW
-vRW
+oyQ
 ngY
 gqD
 gqD
@@ -75560,27 +75505,27 @@ jlB
 uqm
 gqD
 vXB
-csg
-csg
-csg
+cbZ
+cbZ
+cbZ
 bFA
-csg
-csg
-csg
-csg
+cbZ
+cbZ
+cbZ
+cbZ
 exd
 coK
 guX
-csg
-csg
+cbZ
+cbZ
 wtI
 bFA
-csg
-csg
-sca
-csg
-csg
-exd
+cbZ
+cbZ
+bCN
+cbZ
+cbZ
+cFv
 rSS
 jwV
 vRW
@@ -75821,8 +75766,8 @@ nSY
 kyP
 jfm
 rQc
-nfa
 rIC
+sca
 vuA
 lso
 stj
@@ -76094,7 +76039,7 @@ vLq
 lVq
 gVG
 iLW
-ozY
+nLV
 tUb
 pud
 xaO
@@ -76548,27 +76493,27 @@ xzK
 bYt
 bYt
 bYt
-cXC
-cXC
-cXC
+xeN
+xeN
+xeN
 xzK
-cXC
+xeN
 xzK
 xzK
-cXC
+xeN
 xzK
-cXC
-cXC
+xeN
+xeN
 xzK
-cXC
-cXC
+xeN
+xeN
 xzK
-cXC
+xeN
 xzK
-cXC
-cXC
-cXC
-cXC
+xeN
+xeN
+xeN
+xeN
 bYt
 bYt
 xzK
@@ -76805,7 +76750,7 @@ xzK
 xzK
 xzK
 bYt
-cXC
+xeN
 jvD
 jnN
 jvD
@@ -77062,7 +77007,7 @@ bYt
 xzK
 bYt
 bYt
-cXC
+xeN
 jvD
 jnN
 jvD
@@ -77082,7 +77027,7 @@ xzK
 oQk
 scc
 oQk
-cXC
+xeN
 bYt
 bYt
 bYt
@@ -77339,7 +77284,7 @@ bYt
 jvD
 jnN
 jvD
-cXC
+xeN
 bYt
 bYt
 xzK
@@ -77576,7 +77521,7 @@ bYt
 bYt
 bYt
 bYt
-cXC
+xeN
 jvD
 jnN
 jvD
@@ -77628,10 +77573,10 @@ vLq
 voK
 xVq
 hTK
-aMf
+uUj
 vKh
 vKh
-lkZ
+vKh
 lsu
 uwq
 hJC
@@ -77671,11 +77616,11 @@ ffe
 apC
 vOh
 yjS
-oln
+pSL
 jxD
 nGM
 iVm
-gVU
+rWU
 wwF
 ijM
 exg
@@ -77829,11 +77774,11 @@ xzK
 bYt
 bYt
 bYt
-cXC
+xeN
 xzK
-cXC
-cXC
-cXC
+xeN
+xeN
+xeN
 jvD
 jnN
 jvD
@@ -77853,7 +77798,7 @@ xzK
 jvD
 jnN
 jvD
-cXC
+xeN
 bYt
 xzK
 xzK
@@ -77886,9 +77831,9 @@ nRq
 nRq
 vLq
 odd
+gBT
+vKr
 vKh
-vKh
-lkZ
 njU
 uwq
 hJC
@@ -77932,7 +77877,7 @@ dGr
 rLh
 ijM
 aCN
-jAO
+fVm
 wwF
 ijM
 ijM
@@ -78086,7 +78031,7 @@ xzK
 xzK
 xzK
 bYt
-cXC
+xeN
 dLh
 dLh
 dLh
@@ -78110,7 +78055,7 @@ xzK
 jvD
 jnN
 jvD
-cXC
+xeN
 xzK
 xzK
 xzK
@@ -78139,11 +78084,11 @@ bgh
 guX
 rTi
 dJJ
-rBy
-rBy
+dWX
+dWX
 pHl
-aMf
-vKh
+glz
+gVU
 eRF
 pkD
 jpz
@@ -78343,7 +78288,7 @@ bYt
 bYt
 bYt
 bYt
-cXC
+xeN
 dLh
 gRU
 jnN
@@ -78395,12 +78340,12 @@ bxS
 eDE
 guX
 rTi
-hXl
+cWe
+qeT
+qeT
+cWe
+vKh
 jqj
-jqj
-hXl
-uSV
-unC
 sCg
 hen
 dcN
@@ -78440,7 +78385,7 @@ pbo
 dvP
 vQp
 nvb
-enK
+oYJ
 vKh
 lVM
 mCF
@@ -78624,7 +78569,7 @@ xzK
 jvD
 jnN
 jvD
-cXC
+xeN
 xzK
 xzK
 xzK
@@ -78659,7 +78604,7 @@ kCj
 dbP
 ith
 cwu
-amz
+kRC
 iIa
 uwq
 jkV
@@ -78857,11 +78802,11 @@ xzK
 xzK
 bYt
 bYt
-cXC
-cXC
-cXC
+xeN
+xeN
+xeN
 xzK
-cXC
+xeN
 jvD
 jnN
 jvD
@@ -78881,7 +78826,7 @@ xzK
 jvD
 jnN
 jvD
-cXC
+xeN
 bYt
 xzK
 xzK
@@ -78907,16 +78852,16 @@ fHp
 aGM
 sKg
 xxg
-sca
+bCN
 xhd
 gqD
 hXl
 hXl
 gqD
 rFS
-vKh
+jAO
 dBw
-amz
+kRC
 vgF
 uwq
 uYi
@@ -79118,7 +79063,7 @@ bYt
 bYt
 bYt
 bYt
-cXC
+xeN
 jvD
 jnN
 jvD
@@ -79170,8 +79115,8 @@ eqe
 ofZ
 mhf
 hEL
-cHR
-vKh
+lJL
+koG
 dBw
 skT
 hhM
@@ -79202,18 +79147,18 @@ qSb
 xzK
 qSb
 sNx
-onH
+vKh
 onH
 icz
-onH
-onH
+cPk
+oLS
 wqc
-onH
-onH
+cPk
+cPk
 icz
 rHG
-koG
-bCN
+pyO
+pwP
 hsD
 wAr
 sum
@@ -79375,7 +79320,7 @@ xzK
 xzK
 bYt
 bYt
-cXC
+xeN
 jvD
 jnN
 jvD
@@ -79421,16 +79366,16 @@ gqD
 gqD
 gqD
 utb
-sca
+bCN
 bkT
 gqD
 jjp
 uKL
 hEL
 uUj
-vKh
+koG
 dBw
-amz
+kRC
 ljV
 ljV
 ljV
@@ -79459,17 +79404,17 @@ oOR
 qSb
 qSb
 uGa
+vKh
+vKh
+vKh
+vKh
 oSW
-oSW
-tJM
-oSW
-oSW
-oSW
-oSW
-oSW
-oSW
-cbZ
-uMx
+hiZ
+vKh
+vKh
+vKh
+kRC
+pyO
 csx
 wAr
 wAr
@@ -79632,7 +79577,7 @@ xzK
 bYt
 bYt
 bYt
-cXC
+xeN
 jvD
 jnN
 jvD
@@ -79652,7 +79597,7 @@ xzK
 jvD
 jnN
 jvD
-cXC
+xeN
 bYt
 xzK
 xzK
@@ -79678,49 +79623,49 @@ xuW
 qgZ
 gqD
 ycU
-sca
+bCN
 rTi
 gqD
 rve
 rve
 gqD
 uUj
-vKh
-dBw
+koG
+ylL
 jDY
 bcQ
 aUz
-lZb
-lZb
+wuX
+wuX
 sBN
 akB
-lZb
+wuX
 owH
 hXj
 xCc
 pCR
 dmx
-lZb
+wuX
 tuB
 nZa
-lZb
+wuX
 tQu
 mgK
 kDZ
 glO
-lZb
+wuX
 iHo
-lZb
+wuX
 glO
 lop
 pCR
-lZb
+wuX
 xYS
-lZb
-lZb
-lZb
+wuX
+wuX
+wuX
 dmx
-lZb
+sHR
 exv
 lZb
 lZb
@@ -79889,7 +79834,7 @@ xzK
 xzK
 bYt
 bYt
-cXC
+xeN
 jvD
 jnN
 jvD
@@ -79935,14 +79880,14 @@ kKw
 dHl
 gqD
 jrH
-rIC
+sca
 waQ
 ibL
 ofZ
 mhf
 hEL
 lJL
-vKh
+koG
 rMB
 qmR
 pGj
@@ -79962,23 +79907,23 @@ dCa
 dCa
 dCa
 pGj
-qmR
-qmR
-qmR
-qmR
-qmR
+dCa
+dCa
+dCa
+dCa
+dCa
 tjT
-qmR
+dCa
 pWp
-qmR
-qmR
-qmR
-qmR
-qmR
-qmR
-qmR
-qmR
-qmR
+dCa
+dCa
+dCa
+dCa
+dCa
+dCa
+dCa
+dCa
+cHz
 wcb
 wcb
 wcb
@@ -80147,26 +80092,26 @@ xzK
 xzK
 bYt
 xzK
-cXC
-cXC
+xeN
+xeN
 xzK
-cXC
-cXC
+xeN
+xeN
 xzK
-cXC
+xeN
 xzK
-cXC
-cXC
+xeN
+xeN
 xzK
-cXC
+xeN
 xzK
-cXC
-cXC
+xeN
+xeN
 xzK
 xzK
-cXC
+xeN
 xzK
-cXC
+xeN
 bYt
 xzK
 xzK
@@ -80199,9 +80144,9 @@ jjp
 fWR
 hEL
 uUj
-vKh
+koG
 wNN
-vKh
+hiZ
 dnN
 vnl
 jMO
@@ -80449,15 +80394,15 @@ upL
 tJf
 ube
 gqD
-fcT
+ugr
 rTi
 gqD
 rve
 rve
 gqD
 pYt
-aLg
-clI
+lkZ
+cYE
 eDP
 ptG
 ptG
@@ -80706,15 +80651,15 @@ kXt
 kXt
 kXt
 gqD
-fcT
+ugr
 waQ
 xrf
 ofZ
 mhf
 hEL
 xAy
-aLg
-clI
+lkZ
+cYE
 aht
 ptG
 rAo
@@ -80970,7 +80915,7 @@ jjp
 alp
 hEL
 pYt
-aLg
+lkZ
 cYE
 bEP
 ptG
@@ -81484,9 +81429,9 @@ uBc
 oFu
 hYW
 sBk
-aLg
+lkZ
 cYE
-aLg
+eId
 iXA
 wvC
 wcR
@@ -81741,9 +81686,9 @@ hQO
 hQO
 nMZ
 aLg
-aLg
+lkZ
 lpF
-epS
+jkD
 epS
 kJt
 fBh
@@ -81998,9 +81943,9 @@ aYF
 mJY
 jqq
 aLg
-aLg
+lkZ
 cYE
-aLg
+eId
 gnj
 wvC
 wcR
@@ -82053,7 +81998,7 @@ ini
 vYk
 gdw
 vYk
-mtx
+pKN
 xCr
 oHi
 oHi
@@ -82255,7 +82200,7 @@ vHZ
 vHZ
 nsA
 rEu
-rEu
+ngk
 cYE
 ldh
 ptG
@@ -82310,7 +82255,7 @@ lER
 pep
 vBr
 jVx
-wke
+bIf
 pdF
 ebR
 nSK
@@ -82512,7 +82457,7 @@ oCt
 mJY
 nNl
 aLg
-aLg
+lkZ
 cYE
 jpD
 ptG
@@ -82541,7 +82486,7 @@ gRP
 xbm
 iEP
 twq
-ylL
+cwB
 axk
 fbR
 coI
@@ -82562,7 +82507,7 @@ ifT
 arK
 mBo
 gHW
-wke
+gzF
 wke
 hzX
 wke
@@ -82769,7 +82714,7 @@ oCt
 mJY
 jqq
 aLg
-aLg
+lkZ
 cYE
 nKL
 ptG
@@ -82823,7 +82768,7 @@ bZg
 vFK
 eKN
 tTI
-bzK
+qDh
 fnd
 sfW
 xGo
@@ -83026,7 +82971,7 @@ uaN
 tdr
 cKh
 jeX
-jeX
+nkT
 jVl
 qEV
 ptG
@@ -83080,7 +83025,7 @@ dyk
 sHS
 djF
 oQp
-bzK
+lsC
 vEr
 sfW
 bsK
@@ -83283,9 +83228,9 @@ hQO
 hQO
 uaZ
 aLg
-aLg
+lkZ
 cYE
-aLg
+eId
 ptG
 ptG
 ptG
@@ -83337,7 +83282,7 @@ xNR
 oQp
 amr
 oQp
-bzK
+lsC
 nHW
 sfW
 sLc
@@ -83540,7 +83485,7 @@ mVl
 jLY
 uqh
 nIg
-aLg
+lkZ
 cYE
 aMv
 lsM
@@ -83566,7 +83511,7 @@ gHz
 ezF
 iXg
 xRK
-pFf
+emx
 iEP
 cwB
 qZj
@@ -83594,7 +83539,7 @@ ksy
 oQp
 cof
 oQp
-bzK
+lsC
 jqZ
 sdD
 sdD
@@ -83797,7 +83742,7 @@ kXt
 kXt
 kXt
 kXt
-aHy
+oln
 cYE
 aMv
 qEh
@@ -83856,7 +83801,7 @@ idE
 unl
 fcf
 mZX
-lco
+pln
 sdD
 ejm
 llI
@@ -84054,9 +83999,9 @@ lnZ
 upL
 dfl
 rRj
-aFY
+pFf
 cYE
-aFY
+lIW
 aFY
 fhZ
 oaw
@@ -84079,7 +84024,7 @@ iFI
 vJK
 aZJ
 nCn
-pFf
+emx
 owR
 owR
 gUG
@@ -84313,7 +84258,7 @@ gHc
 ggR
 sEy
 cYE
-aLg
+eId
 nSX
 nSX
 nSX
@@ -84336,7 +84281,7 @@ raG
 lyy
 iEP
 hLN
-pFf
+emx
 owR
 kxT
 ury
@@ -84614,8 +84559,8 @@ jty
 kEQ
 rvi
 vgZ
-biT
-biT
+izz
+izz
 rTD
 oUJ
 biT
@@ -84825,7 +84770,7 @@ auH
 auH
 auH
 auH
-hKv
+sdh
 cYE
 jnK
 nSX
@@ -84873,7 +84818,7 @@ xXA
 sti
 orE
 bID
-rKx
+aTa
 rKx
 mOA
 gTH
@@ -85082,9 +85027,9 @@ mNv
 pLg
 tUz
 aAB
-aLg
+lkZ
 cYE
-dKP
+qeM
 nSX
 nHm
 iCP
@@ -85127,7 +85072,7 @@ rIA
 wZl
 kEQ
 jwr
-rKx
+qGr
 mSQ
 ava
 uhc
@@ -85339,7 +85284,7 @@ upg
 rFE
 asc
 aAB
-aLg
+lkZ
 cYE
 sKY
 nSX
@@ -85384,7 +85329,7 @@ aeF
 arm
 kEQ
 dok
-rKx
+qGr
 jSR
 kMQ
 dzG
@@ -85596,7 +85541,7 @@ lvT
 rXI
 cFK
 psL
-aLv
+tug
 cYE
 aWh
 nSX
@@ -85609,7 +85554,7 @@ qvO
 qvO
 qvO
 jep
-jep
+kBz
 swv
 myw
 gXJ
@@ -85618,7 +85563,7 @@ wNM
 lWB
 myp
 dHd
-jep
+wqw
 jep
 qDV
 qZj
@@ -85642,7 +85587,7 @@ jjB
 kEQ
 rbo
 pnm
-jwZ
+jSR
 kMQ
 ujJ
 gTh
@@ -85853,7 +85798,7 @@ aCi
 aCi
 aCi
 aCi
-gnj
+tBm
 cYE
 cZw
 qvO
@@ -85867,15 +85812,15 @@ eSR
 uoC
 jep
 aMV
-sdh
 lWB
+jxZ
 jxZ
 xSn
 jxZ
 jxZ
+jxZ
 lWB
-ngk
-gVr
+wfW
 jep
 rDu
 qZj
@@ -85898,10 +85843,10 @@ rAj
 wDV
 kEQ
 sPw
-rKx
-jwZ
+qGr
+jSR
 rJl
-biT
+gJC
 hTJ
 qAD
 qAD
@@ -86110,7 +86055,7 @@ aeQ
 gxl
 vqx
 aCi
-aLg
+lkZ
 dbk
 sbg
 qvO
@@ -86155,7 +86100,7 @@ rAj
 qTX
 kEQ
 xyF
-rKx
+qGr
 oPC
 pMl
 uhc
@@ -86326,8 +86271,8 @@ juM
 juM
 juM
 juM
-juM
-juM
+cYB
+cYB
 cYB
 juM
 juM
@@ -86367,9 +86312,9 @@ anE
 ank
 cDD
 aCi
-fTM
+tJM
 cYE
-aLg
+eId
 qvO
 qvO
 kQi
@@ -86412,8 +86357,8 @@ rAj
 xQi
 kEQ
 udc
-pnm
-rKx
+lgI
+oZt
 eIb
 gNX
 gAG
@@ -86583,7 +86528,7 @@ jWP
 jWP
 jWP
 jWP
-jWP
+cXC
 jWP
 taO
 jWP
@@ -86624,9 +86569,9 @@ anE
 dWR
 aub
 rLT
-aLg
+lkZ
 drE
-jeX
+uoZ
 lXu
 cGA
 bhc
@@ -86638,17 +86583,17 @@ vPx
 nID
 jep
 lWB
-jxZ
+lWB
 lLl
 rWa
 kwQ
 kwQ
 eiQ
 lKx
-jxZ
+lWB
 opl
 jep
-cWe
+fmz
 niR
 owR
 lQv
@@ -86883,7 +86828,7 @@ ctf
 uLp
 gpo
 aOu
-aLg
+eId
 cvA
 vig
 soq
@@ -86927,8 +86872,8 @@ hZB
 kEQ
 xIJ
 gYt
-hIs
-pgQ
+hfP
+ggm
 nrd
 gJY
 aRJ
@@ -87138,9 +87083,9 @@ afq
 anE
 ewR
 rLT
-aLg
+lkZ
 cYE
-rEu
+iiL
 ddR
 rlM
 bFI
@@ -87180,7 +87125,7 @@ ppw
 qPS
 iKd
 rAj
-bKq
+qTX
 kEQ
 dLc
 hIs
@@ -87395,9 +87340,9 @@ anE
 anE
 dAi
 aCi
-hKv
+sdh
 vDm
-jeX
+uoZ
 aOf
 hdm
 dWi
@@ -87439,7 +87384,7 @@ iKd
 rAj
 qTX
 mqB
-hIs
+iXy
 tcF
 gMD
 ndy
@@ -87654,7 +87599,7 @@ cxR
 aCi
 hKB
 cYE
-aLg
+eId
 sZa
 kvT
 sTR
@@ -87696,7 +87641,7 @@ iKd
 rAj
 qTX
 sJq
-hIs
+iXy
 hIs
 pgQ
 hIs
@@ -87909,9 +87854,9 @@ anE
 anE
 hxZ
 aCi
-vsV
+tSy
 cYE
-aLg
+eId
 vjk
 qvO
 kvT
@@ -87954,8 +87899,8 @@ ioh
 kzn
 bex
 jLe
-hIs
-pgQ
+voZ
+lXP
 dNg
 pjL
 gJY
@@ -88166,9 +88111,9 @@ gIr
 rLT
 aCi
 sbV
-aLg
-cYE
-aLg
+uMx
+miL
+pct
 lkd
 hHC
 kvi
@@ -88189,9 +88134,9 @@ nJE
 kZP
 eLu
 siC
-bJa
-xSg
-xSg
+kqK
+dTS
+dTS
 qbB
 owR
 owR
@@ -88425,27 +88370,27 @@ aLg
 aHj
 aLg
 mdq
-aLg
+pYK
 gld
 mrG
-gQO
-gQO
-gQO
-gQO
-gQO
-gQO
+pCH
+pCH
+pCH
+pCH
+pCH
+pCH
 jSn
-hOC
-jhL
-jhL
-jhL
+pCH
+pCH
+pCH
+pCH
 cxG
-jhL
-jhL
-jhL
-jhL
-jhL
-jhL
+pCH
+pCH
+pCH
+pCH
+pCH
+pCH
 ruE
 pCH
 pCH
@@ -88460,20 +88405,20 @@ tGv
 dHg
 xXd
 ohs
-ahF
+vyl
 kqS
-pCH
+qNN
 nsT
 sTo
 bZU
 nAR
 dlq
-nAR
+rsW
 aCB
 wld
-nAR
+rsW
 pUA
-nAR
+rsW
 xaZ
 bmI
 aeV
@@ -88683,8 +88628,8 @@ qHL
 eMN
 oFT
 fnX
-aLv
-hxj
+iSm
+psv
 pDp
 pDp
 pDp
@@ -88720,10 +88665,10 @@ pDp
 pDp
 psv
 pDp
-uBV
-rAj
+dIN
+ijG
 hlm
-hop
+usL
 xdx
 hop
 hop
@@ -88939,7 +88884,7 @@ aLg
 aHj
 aLg
 deu
-jeX
+hFJ
 pOK
 abe
 nfQ
@@ -88949,47 +88894,47 @@ jBW
 eJc
 pOT
 ezV
-pOT
+pLl
 fPY
-pOT
-pOT
+uIq
+pLl
 pOT
 pOT
 kUT
-myd
+pOT
 qHg
 idX
 fDT
 rRf
-myd
-myd
+pOT
+pOT
 gKX
-myd
-myd
+pOT
+pOT
 mVB
-myd
-myd
+pOT
+pOT
 csA
 eFf
 vfH
-aIU
-myd
+gKX
+pOT
 ttz
 bFw
-anc
+pOT
 jIk
 uft
 olF
 wyT
 bNv
-wyT
+czs
 xDG
 kPx
-wyT
-wyT
+czs
+czs
 iSg
 fTd
-wyT
+czs
 chu
 adT
 adT
@@ -89196,7 +89141,7 @@ xxF
 juN
 pXj
 mwX
-aHj
+xUf
 tlz
 oaK
 oaK
@@ -89235,10 +89180,10 @@ kCy
 gkO
 fXK
 iKd
-dWX
+rAj
 slB
 wha
-mwQ
+eHe
 mwQ
 oDN
 mwQ
@@ -89453,7 +89398,7 @@ baH
 xxF
 hKv
 ojD
-tjv
+mIY
 oaK
 iwT
 suE
@@ -89473,8 +89418,8 @@ pJR
 ghF
 muu
 hBI
-muu
-ghF
+gnr
+nlj
 hVB
 bzx
 bzx
@@ -89730,7 +89675,7 @@ pJR
 sMF
 iAD
 blD
-iAD
+fTo
 wjv
 hVB
 bzx
@@ -89967,7 +89912,7 @@ tve
 xxF
 fTM
 ojD
-bEP
+xKf
 oaK
 wnp
 eYV
@@ -89977,17 +89922,17 @@ csJ
 mMY
 kNQ
 blh
-blh
+pLy
 uDi
 lVt
-lVt
+lCt
 vgV
 hek
 pJR
 hco
 wGv
 iSe
-wGv
+dja
 onp
 hVB
 wFJ
@@ -90224,7 +90169,7 @@ baH
 xxF
 gnj
 ojD
-aLg
+oKQ
 oaK
 xrv
 rBw
@@ -90232,13 +90177,13 @@ hbr
 mNy
 pYy
 mMY
-dCE
+chv
 sCH
 uZQ
 oze
 gle
-sCH
-dmF
+rym
+voF
 wdQ
 pJR
 wVK
@@ -90491,7 +90436,7 @@ gbs
 oZL
 rgC
 bCb
-dCE
+bPt
 ofE
 bZp
 dXk
@@ -90502,7 +90447,7 @@ aXi
 lYk
 qSY
 lYk
-qSY
+vRP
 hVB
 dZR
 bzx
@@ -90522,7 +90467,7 @@ ufw
 iKd
 rAj
 hci
-tug
+wLp
 lwn
 euj
 caT
@@ -90695,7 +90640,7 @@ jWP
 jWP
 jWP
 jWP
-jWP
+xiZ
 jWP
 wsk
 jWP
@@ -90746,20 +90691,20 @@ fmt
 tky
 oaK
 jst
-dCE
+vPs
 uLQ
 iDV
 mzr
 nmY
 xUE
-dmF
+sqz
 vYb
 pJR
 xbp
 oEw
 eqN
 pev
-onp
+ksC
 hVB
 phH
 aYA
@@ -90778,9 +90723,9 @@ dew
 ufw
 xST
 wYk
-ats
+nTR
 oyc
-xXR
+vvM
 jps
 xiU
 efx
@@ -90952,8 +90897,8 @@ juM
 juM
 juM
 juM
-juM
-juM
+cYB
+cYB
 cYB
 juM
 juM
@@ -90995,7 +90940,7 @@ vaX
 xxF
 dKP
 ojD
-aLg
+oKQ
 oaK
 oaK
 dHc
@@ -91003,14 +90948,14 @@ wib
 csJ
 oaK
 bbg
-bbg
+nbG
 qHf
 wzm
 vTL
 dbS
 wRp
 jDJ
-bbg
+nbG
 pJR
 pJR
 pJR
@@ -91035,18 +90980,18 @@ jVC
 xTI
 xBm
 rAj
-dUE
-nkT
+mbr
+kdm
 awD
 cFU
 mrX
 kyW
 ota
-kdm
-dmh
-dmh
-dmh
-dmh
+ckH
+vbt
+vbt
+vbt
+hga
 ldg
 jsw
 bXb
@@ -91252,22 +91197,22 @@ jpd
 xxF
 eiL
 skX
-aLg
+oKQ
 gnj
 eAc
 syJ
 iEp
 iEp
 vFI
-iEp
-iEp
+dhf
+lWg
 rjN
 iEp
 lHZ
 iEp
 esB
-cxl
-iEp
+hew
+lWg
 dbK
 sJG
 iEp
@@ -91276,13 +91221,13 @@ dIF
 jqD
 iEp
 aLz
-gBS
+cnf
 rlT
 phA
 aiw
 kze
 dga
-vKr
+bQz
 cCx
 wKo
 kCy
@@ -91292,7 +91237,7 @@ tFf
 xTI
 tMw
 rAj
-dUE
+mbr
 dNX
 ris
 ris
@@ -91303,7 +91248,7 @@ cJC
 oxT
 kPl
 aWN
-dmh
+its
 xsR
 qrY
 dMd
@@ -91508,25 +91453,25 @@ xxF
 xvy
 xxF
 fUd
-ojD
-jeX
+uAq
+uim
 mxv
 raq
 ttC
-ttC
-ttC
+wat
+wat
 rds
 oxR
 uyT
 uSj
 lMm
 lMm
-uyT
+ryW
 sBW
 vjI
 wHy
 pUu
-sBW
+jPh
 fWj
 wQT
 wfz
@@ -91560,9 +91505,9 @@ clG
 clG
 clG
 clG
-dmh
+its
 ari
-mEk
+ydX
 bXb
 iOL
 tAF
@@ -91766,7 +91711,7 @@ jUN
 xxF
 aLg
 ojD
-aLg
+oKQ
 bDY
 bDY
 bDY
@@ -91789,8 +91734,8 @@ hPH
 hPH
 hPH
 cJP
-iEp
-qnM
+weL
+xXj
 fir
 tvl
 tvl
@@ -91817,7 +91762,7 @@ mQx
 oum
 ifD
 clG
-dmh
+its
 ari
 tCH
 bXb
@@ -92031,7 +91976,7 @@ fwR
 hIe
 oZO
 xAE
-cxl
+bot
 dvO
 pKc
 cDx
@@ -92046,7 +91991,7 @@ sIa
 dgU
 hPH
 vdc
-uyT
+mke
 bbU
 kfg
 iLh
@@ -92074,7 +92019,7 @@ lsB
 qbm
 gAC
 clG
-dmh
+its
 ari
 nEP
 bXb
@@ -92279,8 +92224,8 @@ xxF
 xxF
 xxF
 aLg
-dnG
-aLg
+skX
+oKQ
 bDY
 ptq
 gzc
@@ -92288,7 +92233,7 @@ rwZ
 dZj
 bDY
 diY
-cxl
+bot
 jSV
 cxV
 kFO
@@ -92303,8 +92248,8 @@ wti
 khf
 hPH
 nCM
-iEp
-qnM
+weL
+xXj
 bpq
 fBK
 qnM
@@ -92331,9 +92276,9 @@ mWB
 xJg
 tmG
 qVa
+pnp
 ari
-ari
-dmh
+fLD
 bXb
 bRU
 ftH
@@ -92536,8 +92481,8 @@ lVS
 ePO
 bbt
 ojA
-ojD
-aLg
+ery
+oKQ
 svr
 vYB
 udV
@@ -92545,7 +92490,7 @@ xQk
 sTi
 bDY
 wvi
-cxl
+bot
 jSV
 cxV
 fwt
@@ -92560,8 +92505,8 @@ wti
 mUi
 hPH
 ljg
-iEp
-qnM
+weL
+xXj
 bpq
 fBK
 bBK
@@ -92578,7 +92523,7 @@ xTI
 gEE
 rAj
 qjw
-eFP
+xag
 lGf
 uAB
 hKl
@@ -92590,7 +92535,7 @@ wIX
 clG
 isV
 ari
-mEk
+ydX
 whG
 gkc
 whG
@@ -92802,7 +92747,7 @@ bDY
 bDY
 bDY
 rYy
-cxl
+bot
 jSV
 cxV
 hwV
@@ -92817,8 +92762,8 @@ mwf
 oTW
 hPH
 rXr
-iEp
-qnM
+weL
+xXj
 bpq
 fBK
 bBK
@@ -92835,7 +92780,7 @@ xTI
 iKd
 rAj
 qjw
-eFP
+xag
 tTE
 tHj
 eCG
@@ -93074,8 +93019,8 @@ hPH
 hPH
 hPH
 fsz
-iEp
-qnM
+weL
+xXj
 bpq
 fBK
 kns
@@ -93093,7 +93038,7 @@ nKE
 ioh
 ybg
 tEb
-eFP
+xag
 eFP
 tEb
 vyK
@@ -93102,7 +93047,7 @@ clG
 clG
 clG
 clG
-kdm
+cWb
 wLp
 ocl
 whG
@@ -93308,7 +93253,7 @@ wox
 xZg
 aLg
 ojD
-aLg
+oKQ
 bDY
 plH
 gSc
@@ -93328,11 +93273,11 @@ txa
 mOs
 iEp
 iEp
-syJ
-syJ
-syJ
-iEp
-qnM
+dJv
+dJv
+dJv
+lWg
+xXj
 bpq
 ceG
 qnM
@@ -93361,7 +93306,7 @@ ora
 oJQ
 mEk
 ngL
-dmh
+fLD
 whG
 scC
 nwe
@@ -93585,11 +93530,11 @@ arc
 pAc
 pAc
 aba
-oxR
+hkT
 fki
 nzl
-iEp
-qnM
+wfx
+jfv
 bmZ
 uyN
 qnM
@@ -93606,7 +93551,7 @@ dAb
 uBV
 rAj
 mbr
-tBm
+iKd
 cff
 aGA
 ora
@@ -93616,7 +93561,7 @@ ewO
 iaY
 ora
 fgy
-dmh
+its
 ari
 ikV
 whG
@@ -93832,7 +93777,7 @@ hmb
 ozs
 rdy
 jSV
-xkn
+caw
 dnx
 fZB
 qGs
@@ -93873,7 +93818,7 @@ mkx
 pUa
 ora
 mQL
-dmh
+its
 ari
 pfQ
 whG
@@ -94079,7 +94024,7 @@ wox
 xZg
 aLg
 ojD
-qEh
+gou
 bDY
 mpq
 jJA
@@ -94091,9 +94036,9 @@ hxo
 dvO
 icy
 xEC
-kFO
-qGs
-rUt
+mNe
+lXJ
+aTk
 lTq
 wEP
 vAU
@@ -94130,7 +94075,7 @@ cpJ
 viX
 ora
 chN
-dmh
+its
 ari
 rvE
 fKw
@@ -94339,11 +94284,11 @@ ojD
 wAI
 bDY
 rhN
-uPM
+ybq
 uPM
 uPM
 nLW
-nLW
+oFH
 xsy
 bbR
 gYJ
@@ -94377,7 +94322,7 @@ dAs
 iKd
 rAj
 mbr
-tBm
+iKd
 otZ
 bck
 veR
@@ -94387,7 +94332,7 @@ cSH
 eVX
 ora
 qxp
-dmh
+its
 ari
 lIT
 fKw
@@ -94607,7 +94552,7 @@ fvb
 rAN
 cpL
 oyw
-jfh
+qGz
 aLE
 wEP
 eEA
@@ -94646,7 +94591,7 @@ ora
 oMf
 mEk
 ari
-dmh
+fLD
 ngd
 jaW
 spQ
@@ -94850,12 +94795,12 @@ wox
 sEg
 aLg
 ojD
-aLg
+oKQ
 bDY
 qiI
 jtY
-jtY
-jtY
+xfm
+dcK
 hya
 xoT
 hmb
@@ -94889,7 +94834,7 @@ xzK
 xzK
 dAs
 nKE
-gBT
+ioh
 rMS
 ora
 ora
@@ -94901,7 +94846,7 @@ ora
 mJS
 ora
 kDD
-dmh
+its
 ari
 hfd
 iRK
@@ -95154,13 +95099,13 @@ qZB
 xQU
 kyW
 oDD
-kdm
-ari
+vLj
+rlP
 wjI
-dmh
+sok
 vOq
 ari
-dmh
+fLD
 ihd
 vAo
 jRW
@@ -95363,7 +95308,7 @@ wox
 wox
 xZg
 rxv
-asw
+skX
 bqS
 bDY
 myl
@@ -95405,8 +95350,8 @@ xVi
 vFM
 nEW
 dGu
-nkT
-dWx
+kdm
+uQz
 ggU
 xSf
 hmf
@@ -95417,7 +95362,7 @@ dmh
 dmh
 dmh
 ctE
-dmh
+fLD
 mPh
 aFd
 hTS
@@ -95621,7 +95566,7 @@ xZg
 sEg
 pdL
 yjl
-jeX
+uim
 xmY
 npc
 npc
@@ -95669,12 +95614,12 @@ pdM
 hEJ
 oza
 jso
-ari
-ari
-ari
-ari
-ari
-dmh
+wTs
+wTs
+wTs
+wTs
+jFT
+fLD
 lVL
 aRh
 vAo
@@ -95878,7 +95823,7 @@ rWo
 gvk
 aLg
 lJV
-aLg
+oKQ
 xTI
 xTI
 xTI
@@ -95931,7 +95876,7 @@ eAq
 kFL
 feR
 wfu
-dmh
+fLD
 nxX
 xhr
 pHb
@@ -96135,7 +96080,7 @@ lBw
 qje
 auJ
 ttT
-vFM
+cMs
 xOt
 ihy
 gyV
@@ -96188,7 +96133,7 @@ bCp
 tya
 rhX
 nxe
-dmh
+fLD
 mBT
 vAo
 tmm
@@ -96392,7 +96337,7 @@ sEg
 sEg
 jKr
 rQZ
-xIk
+wUq
 sGS
 xIk
 xIk
@@ -96651,40 +96596,40 @@ aLZ
 dbT
 xYU
 htM
-vFM
-vFM
-vFM
-xYU
+idh
+idh
+idh
+idh
 wLg
-xYU
-fGO
-vFM
+idh
+htM
+idh
 kTL
-vFM
-xYU
-xYU
+idh
+idh
+idh
 wTV
 xmh
-xYU
+idh
 wLg
 wLg
-xYU
+idh
 rQU
-vFM
+idh
 iJL
-vFM
-vFM
-xYU
+idh
+idh
+xGJ
 bTq
 jMb
-fGO
-xYU
-xYU
+oMn
+vFM
+vFM
 xXf
 gbQ
 oVX
 hpF
-xYU
+vFM
 jMb
 rBJ
 cgi
@@ -96702,7 +96647,7 @@ iNP
 laP
 izZ
 eIN
-mEk
+ydX
 sGE
 jaW
 spQ
@@ -96929,7 +96874,7 @@ wwP
 eVP
 nzg
 fOC
-nzg
+vGu
 ksN
 fjg
 shv
@@ -97456,7 +97401,7 @@ ndj
 vrp
 qAm
 kxa
-qAm
+ixl
 wWE
 wEM
 agx
@@ -97711,9 +97656,9 @@ uff
 rzo
 rzo
 xJJ
+neL
 psE
-pDf
-psE
+wzW
 vgD
 rzo
 rzo
@@ -97968,9 +97913,9 @@ uff
 rzo
 rzo
 xJJ
+neL
 psE
-pDf
-psE
+wzW
 vgD
 rzo
 rzo
@@ -98225,9 +98170,9 @@ ogK
 hrw
 xKk
 xJJ
+neL
 psE
-pDf
-psE
+wzW
 vgD
 wWB
 hrw
@@ -98482,9 +98427,9 @@ wxR
 wxR
 uff
 hwf
+neL
 psE
-pDf
-psE
+wzW
 amX
 xyZ
 wxR
@@ -98708,7 +98653,7 @@ srT
 nUo
 pXd
 pXd
-tSy
+pXd
 pXd
 pXd
 gPI
@@ -98739,9 +98684,9 @@ wxR
 wxR
 uff
 fss
-ptr
-pDm
-pSB
+vTW
+yaX
+vEl
 fzC
 xyZ
 wxR
@@ -98974,10 +98919,10 @@ cDr
 deD
 fkS
 qPx
-qPx
-qPx
-qPx
-qPx
+iek
+iek
+iek
+kMY
 kLf
 ojW
 ygP
@@ -98996,9 +98941,9 @@ gDv
 agx
 ndj
 xJJ
-psE
-pDm
-psE
+neL
+yaX
+wzW
 vgD
 wEM
 agx
@@ -99233,7 +99178,7 @@ mWX
 eIz
 uIW
 teX
-teX
+iki
 geF
 nhG
 vKV
@@ -99253,9 +99198,9 @@ uff
 rzo
 rzo
 xJJ
-psE
-pDm
-psE
+neL
+yaX
+wzW
 vgD
 rzo
 rzo
@@ -99510,9 +99455,9 @@ uff
 rzo
 rzo
 xJJ
-psE
-pDm
-psE
+neL
+yaX
+wzW
 vgD
 rzo
 rzo
@@ -99767,9 +99712,9 @@ ogK
 hrw
 xKk
 xJJ
-psE
-pDm
-psE
+neL
+yaX
+wzW
 vgD
 wWB
 hrw
@@ -100024,9 +99969,9 @@ wxR
 wxR
 uff
 xJJ
-psE
-pDm
-psE
+neL
+yaX
+wzW
 vgD
 xyZ
 wxR
@@ -100262,11 +100207,11 @@ svg
 hQF
 fVo
 lcJ
-qaU
-qPx
-qPx
-qPx
-qPx
+imE
+iek
+iek
+iek
+iek
 vPQ
 gur
 nvx
@@ -100281,9 +100226,9 @@ vrS
 sbE
 maM
 jZF
-psE
+neL
 yaX
-psE
+wzW
 uPw
 ftU
 ftU
@@ -100520,13 +100465,13 @@ kLe
 fVo
 tTF
 dOT
-cbi
-cbi
-cbi
-cbi
-cbi
 teX
 teX
+teX
+teX
+teX
+teX
+iki
 tQM
 tzi
 gwz
@@ -100534,13 +100479,13 @@ gzN
 gOE
 tbC
 phN
-yaX
-yaX
-yaX
-yaX
-yaX
+gef
+gef
+gef
+gef
+tge
 pDK
-psE
+wzW
 liy
 lul
 lul
@@ -100581,9 +100526,9 @@ nxB
 uyr
 wGV
 dWL
-ahw
+vZp
 eOt
-ahw
+ybS
 dWL
 wyy
 wyy
@@ -100713,11 +100658,11 @@ bWJ
 bRT
 bRT
 iFd
-liU
-liU
-liU
-liU
-liU
+bYt
+bYt
+bYt
+bYt
+bYt
 iFd
 bRT
 bRT
@@ -100795,9 +100740,9 @@ ous
 oHL
 buD
 phS
-psE
+ptf
 yaX
-iRT
+tbA
 lqO
 lAp
 lAp
@@ -100970,11 +100915,11 @@ kiR
 bSK
 bRT
 iFd
-liU
-liU
-liU
-liU
-liU
+bYt
+bYt
+bYt
+bYt
+bYt
 iFd
 bSK
 bRT
@@ -101054,7 +100999,7 @@ nWO
 nWO
 jDf
 pEh
-psE
+wzW
 qaZ
 qoa
 qoa
@@ -101227,11 +101172,11 @@ jtW
 bSK
 bRT
 iFd
-liU
-liU
+bYt
+bYt
 pai
-liU
-liU
+bYt
+bYt
 iFd
 kiR
 bSK
@@ -101309,9 +101254,9 @@ wxR
 wxR
 uff
 piK
-psE
+neL
 pEh
-psE
+wzW
 lrp
 mam
 mmq
@@ -101484,11 +101429,11 @@ jtW
 bRT
 bSK
 iFd
-liU
-liU
-liU
-liU
-liU
+bYt
+bYt
+bYt
+bYt
+bYt
 oiH
 oQs
 bSK
@@ -101546,7 +101491,7 @@ cFd
 pdz
 qAs
 oay
-teX
+bCj
 rKk
 xms
 rdk
@@ -101566,9 +101511,9 @@ wxR
 wxR
 uff
 piZ
-psE
+neL
 pEh
-psE
+wzW
 qbt
 qbt
 qbt
@@ -101741,11 +101686,11 @@ wZN
 bRT
 wZN
 iFd
-liU
-liU
-liU
-liU
-liU
+bYt
+bYt
+bYt
+bYt
+bYt
 iFd
 oQF
 bRT
@@ -101823,9 +101768,9 @@ ouH
 wxR
 uff
 piZ
-psE
+neL
 pEh
-psE
+wzW
 qxj
 qxj
 qxj
@@ -102080,9 +102025,9 @@ wxR
 wxR
 uff
 piZ
-psE
+neL
 pEh
-psE
+wzW
 qxj
 qxj
 qxj
@@ -102337,9 +102282,9 @@ wxR
 wxR
 uff
 iXS
-psE
+neL
 pEh
-psE
+wzW
 qxj
 qxj
 qxD
@@ -102596,9 +102541,9 @@ nWO
 nWO
 pup
 pFq
-psE
-psE
-psE
+aOa
+tyW
+ebQ
 nWO
 nWO
 tgs
@@ -102769,11 +102714,11 @@ wZN
 bRT
 bQw
 iFd
-liU
-liU
-liU
-liU
-liU
+bYt
+bYt
+bYt
+bYt
+bYt
 iFd
 oQF
 bRT
@@ -102851,11 +102796,11 @@ xwg
 xwg
 oSV
 nWO
-pts
+tXF
 pFX
 qGd
-pts
-pts
+epN
+hht
 nWO
 evM
 tgs
@@ -103026,11 +102971,11 @@ kiR
 bRT
 bRT
 iFd
-liU
-liU
-liU
-liU
-liU
+bYt
+bYt
+bYt
+bYt
+bYt
 iFd
 jtW
 bRT
@@ -103283,11 +103228,11 @@ jtW
 bSK
 bRT
 iFd
-liU
-liU
+bYt
+bYt
 pai
-liU
-liU
+bYt
+bYt
 iFd
 jtW
 bSK
@@ -103540,11 +103485,11 @@ jtW
 bSK
 pai
 iFd
-liU
-liU
-liU
-liU
-liU
+bYt
+bYt
+bYt
+bYt
+bYt
 iFd
 bRT
 bSK
@@ -103797,11 +103742,11 @@ bRT
 bRT
 pai
 lay
-liU
-liU
-liU
-liU
-liU
+bYt
+bYt
+bYt
+bYt
+bYt
 iFd
 bRT
 xKv
@@ -104441,7 +104386,7 @@ wkj
 wkj
 wkj
 wkj
-saj
+bYt
 bYt
 jWW
 jWW
@@ -106451,23 +106396,23 @@ xzK
 xzK
 xzK
 bYt
-cXC
-cXC
-cXC
-cXC
+xeN
+xeN
+xeN
+xeN
 xzK
-cXC
-cXC
+xeN
+xeN
 xzK
 mVG
 xzK
-cXC
+xeN
 xzK
 xzK
-cXC
-cXC
-cXC
-cXC
+xeN
+xeN
+xeN
+xeN
 bYt
 bYt
 xzK
@@ -106724,7 +106669,7 @@ mUS
 mUS
 mUS
 mUS
-cXC
+xeN
 bYt
 xzK
 xzK
@@ -106981,7 +106926,7 @@ wHi
 wHi
 wHi
 wHi
-cXC
+xeN
 bYt
 bYt
 bYt
@@ -107495,7 +107440,7 @@ xzK
 xzK
 bYt
 xzK
-cXC
+xeN
 bYt
 xzK
 xzK
@@ -107736,7 +107681,7 @@ xzK
 xzK
 xzK
 bYt
-cXC
+xeN
 mUS
 mUS
 mUS
@@ -108009,7 +107954,7 @@ wHi
 wHi
 wHi
 wHi
-cXC
+xeN
 bYt
 bYt
 xzK
@@ -108250,7 +108195,7 @@ xzK
 xzK
 xzK
 bYt
-cXC
+xeN
 mUS
 mUS
 mUS
@@ -108266,7 +108211,7 @@ mUS
 mUS
 mUS
 mUS
-cXC
+xeN
 bYt
 bYt
 bYt
@@ -108507,7 +108452,7 @@ xzK
 xzK
 xzK
 bYt
-cXC
+xeN
 xzK
 bYt
 xzK
@@ -108523,7 +108468,7 @@ xzK
 xzK
 bYt
 xzK
-cXC
+xeN
 bYt
 bYt
 xzK
@@ -108764,7 +108709,7 @@ xzK
 xzK
 bYt
 bYt
-cXC
+xeN
 mUS
 mUS
 mUS
@@ -109021,7 +108966,7 @@ xzK
 bYt
 bYt
 bYt
-cXC
+xeN
 wHi
 wHi
 wHi
@@ -109037,7 +108982,7 @@ wHi
 wHi
 wHi
 wHi
-cXC
+xeN
 bYt
 xzK
 xzK
@@ -109294,7 +109239,7 @@ mUS
 mUS
 mUS
 mUS
-cXC
+xeN
 bYt
 bYt
 bYt
@@ -109535,7 +109480,7 @@ xzK
 xzK
 bYt
 bYt
-cXC
+xeN
 xzK
 bYt
 xzK
@@ -109808,7 +109753,7 @@ mUS
 mUS
 mUS
 mUS
-cXC
+xeN
 bYt
 bYt
 xzK
@@ -110049,7 +109994,7 @@ bYt
 bYt
 xzK
 bYt
-cXC
+xeN
 wHi
 wHi
 wHi
@@ -110306,7 +110251,7 @@ xzK
 xzK
 xzK
 bYt
-cXC
+xeN
 mUS
 mUS
 mUS
@@ -110322,7 +110267,7 @@ mUS
 mUS
 mUS
 mUS
-cXC
+xeN
 bYt
 bYt
 bYt
@@ -110579,7 +110524,7 @@ xzK
 xzK
 bYt
 xzK
-cXC
+xeN
 bYt
 bYt
 xzK
@@ -110820,7 +110765,7 @@ xzK
 bYt
 bYt
 bYt
-cXC
+xeN
 mUS
 mUS
 mUS
@@ -110836,7 +110781,7 @@ mUS
 mUS
 mUS
 mUS
-cXC
+xeN
 bYt
 xzK
 xzK
@@ -111334,7 +111279,7 @@ xzK
 xzK
 xzK
 bYt
-cXC
+xeN
 mUS
 mUS
 mUS
@@ -111350,7 +111295,7 @@ mUS
 eku
 mUS
 mUS
-cXC
+xeN
 bYt
 bYt
 xzK
@@ -111593,21 +111538,21 @@ bYt
 bYt
 xzK
 xzK
-cXC
-cXC
+xeN
+xeN
 xzK
-cXC
+xeN
 xzK
 xzK
 wHi
 xzK
-cXC
-cXC
-cXC
-cXC
-cXC
-cXC
-cXC
+xeN
+xeN
+xeN
+xeN
+xeN
+xeN
+xeN
 bYt
 xzK
 xzK
@@ -111854,11 +111799,11 @@ bYt
 bYt
 bYt
 bYt
-cXC
+xeN
 mVG
 wHi
 mVG
-cXC
+xeN
 bYt
 bYt
 bYt
@@ -112111,7 +112056,7 @@ xzK
 xzK
 bYt
 bYt
-cXC
+xeN
 mVG
 iZs
 mVG
@@ -112368,7 +112313,7 @@ xzK
 bYt
 bYt
 bYt
-cXC
+xeN
 mVG
 mVG
 mVG
@@ -112627,9 +112572,9 @@ bYt
 bYt
 xzK
 xzK
-cXC
+xeN
 xzK
-cXC
+xeN
 bYt
 xzK
 bYt
@@ -153214,9 +153159,9 @@ jep
 lWV
 vXc
 xmR
-xPX
-xPX
-ttw
+xmR
+uNu
+xmR
 xmR
 vXc
 vZu
@@ -159822,7 +159767,7 @@ ymg
 ymg
 ymg
 ymg
-ymg
+liU
 ymg
 ymg
 ymg
@@ -166327,8 +166272,8 @@ nss
 nHZ
 nWO
 tBU
-ous
-glz
+ioF
+psE
 oSQ
 tXs
 xhM


### PR DESCRIPTION
Changes:

- Removes the r-wall armor from the lower level, replaces with r-girders. This is prep for whenever the wallening hits so we don't get all wonky. Still should be plenty of armor against space dust.
- Removed a few of decals which were hidden beneath walls, leftover from the original mapper.
- Replaced a few instances of *decal* lattices with actual lattices.
- Every grille in space should now have a lattice underneath it for consistency.
- Few disposal fixes.
- Couple more directional wallmounted object fixes.

A E S T H E T I C S:
Tons and tons of the square corner decals have been axed in favor of the filled lines. It's sexy. Screw you.

Medical: 
![image](https://user-images.githubusercontent.com/28007787/132613780-2ce7a7ef-4c02-4022-bf7d-a24b9b44fb53.png)

Supply, command:
![image](https://user-images.githubusercontent.com/28007787/132613830-0547897c-a470-4b12-9b2f-61a1e093a7a1.png)

Science: 
![image](https://user-images.githubusercontent.com/28007787/132613860-2565240a-ab8b-499e-91c3-d218706c7287.png)

Security, now with 100% more dark tiles (and 100% more vending machines):
![image](https://user-images.githubusercontent.com/28007787/132613911-bdee2364-0dc4-4c75-8544-6a12d858ddd3.png)
