### PR TITLE
Fax machine fixes and tweaks

### DIFF
--- a/_maps/map_files/LimaStation/LimaStation.dmm
+++ b/_maps/map_files/LimaStation/LimaStation.dmm
@@ -27824,7 +27824,7 @@
 "mkx" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/fax_machine,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/carpet/royalblue,
 /area/command/heads_quarters/hop)
 "mli" = (
@@ -35682,7 +35682,7 @@
 "pml" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/telescreen/entertainment/directional/south,
-/obj/machinery/fax_machine,
+/obj/machinery/fax_machine/recieving_disabled,
 /turf/open/floor/carpet/orange,
 /area/service/lawoffice)
 "pmo" = (

--- a/jollystation_modules/code/__DEFINES/paperwork_defines.dm
+++ b/jollystation_modules/code/__DEFINES/paperwork_defines.dm
@@ -17,9 +17,5 @@
 /// Global list of all admin fax machine destinations
 GLOBAL_LIST_INIT(admin_fax_destinations, list(SYNDICATE_FAX_MACHINE, CENTCOM_FAX_MACHINE))
 
-/// VV dropdowns for the fax machine
-#define VV_SEND_FAX "send_fax"
-#define VV_SEND_MARKED_FAX "send_marked_fax"
-
 /// Text macro for replying to a message with a paper fax.
 #define ADMIN_FAX_REPLY(machine) "(<a href='?_src_=holder;[HrefToken(TRUE)];FaxReply=[REF(machine)]'>FAX</a>)"

--- a/tgui/packages/tgui/interfaces/_FaxMachine.js
+++ b/tgui/packages/tgui/interfaces/_FaxMachine.js
@@ -78,8 +78,8 @@ export const _FaxMachine = (props, context) => {
                     setTab(2);
                     act('read_last_received');
                   }}>
-                  <Stack grow width="100%">
-                    <Stack.Item grow textAlign="left">
+                  <Stack>
+                    <Stack.Item textAlign="left">
                       <b>received Faxes </b>
                     </Stack.Item>
                     {received_paper && !!unread_message && (
@@ -152,7 +152,6 @@ export const _FaxMachine = (props, context) => {
                   <Stack.Item grow>
                     <Dropdown
                       width="100%"
-                      height="100%"
                       selected={selectedDestination}
                       options={destination_options}
                       onSelected={dest => { setDestination(dest); }} />
@@ -218,7 +217,7 @@ export const _FaxMachine = (props, context) => {
             <Stack.Item height={3} mb={1}>
               {!!selectedPaper && (
                 <Stack vertical align="center" >
-                  <Stack.Item grow>
+                  <Stack.Item>
                     <b>
                       To fulfill this paperwork, stamp accurately
                       and answer the following:


### PR DESCRIPTION
- Fixes the fax ui, which broke due to some tgui core changes
- Fixes the fax machine saying span_whatever in world 
- Allows the fax machine to be unwrenched and moved
- Admin papers that fail to send now qdel automatically (didn't matter that much)
- Faxes now start receiving paperwork by default, added a subtype that doesn't receive by default (for the lawyer and hop)
- The source machine should no longer appear in the destination list of itself
- Restoring routing information now uses the define