### PR TITLE
Fixes loadout + flavor text pref runtimes

### DIFF
--- a/jollystation_modules/code/modules/client/preferences.dm
+++ b/jollystation_modules/code/modules/client/preferences.dm
@@ -1,5 +1,17 @@
 // -- Defines for player prefs --
 /datum/preferences/update_preferences(current_version, savefile/S)
 	. = ..()
+	// Update old loadout lists to new loadout lists.
 	if (current_version < 41)
-		write_preference(GLOB.preference_entries[/datum/preference/loadout], update_loadout_list(read_preference(/datum/preference/loadout)))
+		// We basically perform a read on /datum/preference/loadout without deserializing.
+		// If the list is deserealized, the sanitization proc removes
+		// all the values we want to update, defeating the point of trying to update.
+		var/datum/preference/preference_entry = GLOB.preference_entries[/datum/preference/loadout]
+		var/savefile/our_file = get_savefile_for_savefile_identifier(preference_entry.savefile_identifier)
+		var/list/loadout_list
+
+		if (!isnull(our_file))
+			READ_FILE(our_file[preference_entry.savefile_key], loadout_list)
+
+		if (LAZYLEN(loadout_list))
+			write_preference(preference_entry, update_loadout_list(loadout_list))

--- a/jollystation_modules/code/modules/client/preferences/loadout_preference.dm
+++ b/jollystation_modules/code/modules/client/preferences/loadout_preference.dm
@@ -19,6 +19,9 @@
 	for(var/datum/loadout_item/item as anything in loadout_list_to_datums(value))
 		item.post_equip_item(prefs, target)
 
+/datum/preference/loadout/serialize(input, datum/preferences/preferences)
+	return sanitize_loadout_list(input)
+
 /datum/preference/loadout/deserialize(input, datum/preferences/preferences)
 	return sanitize_loadout_list(input)
 

--- a/jollystation_modules/code/modules/client/preferences/multiline_preferences.dm
+++ b/jollystation_modules/code/modules/client/preferences/multiline_preferences.dm
@@ -1,21 +1,6 @@
 /datum/preference/multiline_text
 	abstract_type = /datum/preference/multiline_text
-	savefile_identifier = PREFERENCE_CHARACTER
-	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
-	priority = PREFERENCE_PRIORITY_NAMES
 	can_randomize = FALSE
-
-/datum/preference/multiline_text/apply_to_human(mob/living/carbon/human/target, value)
-	if(!value)
-		return FALSE
-
-	if(istype(target, /mob/living/carbon/human/dummy))
-		return FALSE
-
-	if(!target.linked_flavor)
-		return add_mob_flavor_text(target)
-
-	return TRUE
 
 /datum/preference/multiline_text/deserialize(input, datum/preferences/preferences)
 	return STRIP_HTML_SIMPLE("[input]", MAX_FLAVOR_LEN)
@@ -29,52 +14,52 @@
 /datum/preference/multiline_text/create_default_value()
 	return null
 
-/datum/preference/multiline_text/flavor
+/datum/preference/multiline_text/flavor_datum
+	abstract_type = /datum/preference/multiline_text/flavor_datum
+	savefile_identifier = PREFERENCE_CHARACTER
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	priority = PREFERENCE_PRIORITY_NAMES
+
+/datum/preference/multiline_text/flavor_datum/apply_to_human(mob/living/carbon/human/target, value)
+	if(!value)
+		return
+
+	if(istype(target, /mob/living/carbon/human/dummy))
+		return
+
+	return target.linked_flavor || add_or_get_mob_flavor_text(target)
+
+/datum/preference/multiline_text/flavor_datum/flavor
 	savefile_key = "flavor_text"
 
-/datum/preference/multiline_text/flavor/apply_to_human(mob/living/carbon/human/target, value)
-	. = ..()
-	if(!.)
-		return
+/datum/preference/multiline_text/flavor_datum/flavor/apply_to_human(mob/living/carbon/human/target, value)
+	var/datum/flavor_text/our_flavor = ..()
+	our_flavor?.flavor_text = value
 
-	target.linked_flavor.flavor_text = value
-
-/datum/preference/multiline_text/exploitable
+/datum/preference/multiline_text/flavor_datum/exploitable
 	savefile_key = "exploitable_info"
 
-/datum/preference/multiline_text/exploitable/apply_to_human(mob/living/carbon/human/target, value)
-	. = ..()
-	if(!.)
-		return
+/datum/preference/multiline_text/flavor_datum/exploitable/apply_to_human(mob/living/carbon/human/target, value)
+	var/datum/flavor_text/our_flavor = ..()
+	our_flavor?.expl_info = value
 
-	target.linked_flavor.expl_info = value
-
-/datum/preference/multiline_text/general
+/datum/preference/multiline_text/flavor_datum/general
 	savefile_key = "general_records"
 
-/datum/preference/multiline_text/general/apply_to_human(mob/living/carbon/human/target, value)
-	. = ..()
-	if(!.)
-		return
+/datum/preference/multiline_text/flavor_datum/general/apply_to_human(mob/living/carbon/human/target, value)
+	var/datum/flavor_text/our_flavor = ..()
+	our_flavor?.gen_records = value
 
-	target.linked_flavor.gen_records = value
-
-/datum/preference/multiline_text/security
+/datum/preference/multiline_text/flavor_datum/security
 	savefile_key = "security_records"
 
-/datum/preference/multiline_text/security/apply_to_human(mob/living/carbon/human/target, value)
-	. = ..()
-	if(!.)
-		return
+/datum/preference/multiline_text/flavor_datum/security/apply_to_human(mob/living/carbon/human/target, value)
+	var/datum/flavor_text/our_flavor = ..()
+	our_flavor?.sec_records = value
 
-	target.linked_flavor.sec_records = value
-
-/datum/preference/multiline_text/medical
+/datum/preference/multiline_text/flavor_datum/medical
 	savefile_key = "medical_records"
 
-/datum/preference/multiline_text/medical/apply_to_human(mob/living/carbon/human/target, value)
-	. = ..()
-	if(!.)
-		return
-
-	target.linked_flavor.med_records = value
+/datum/preference/multiline_text/flavor_datum/medical/apply_to_human(mob/living/carbon/human/target, value)
+	var/datum/flavor_text/our_flavor = ..()
+	our_flavor?.med_records = value

--- a/jollystation_modules/code/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
+++ b/jollystation_modules/code/modules/loadouts/loadout_ui/loadout_outfit_helpers.dm
@@ -64,11 +64,14 @@
 
 
 /*
- * Removes all invalid paths from loadout lists.
+ * Changes the loadout list from being [slot] to [path]
+ * to [path] to [list of data].
+ *
  * This is for updating old loadout lists (pre-datumization)
  * to new loadout lists (the formatting was changed).
  *
- * If you're looking at loadouts fresh, you DON'T need this proc.
+ * If you're looking at loadouts NOW,
+ * you DON'T need this proc or the savefile update extension.
  *
  * passed_list - the loadout list we're sanitizing.
  *

--- a/jollystation_modules/code/modules/mob/living/carbon/human/examine.dm
+++ b/jollystation_modules/code/modules/mob/living/carbon/human/examine.dm
@@ -35,25 +35,23 @@
 	if(known_identity)
 		expanded_examine += known_identity.get_flavor_and_records_links(user)
 
-	if(linked_flavor)
-		// Admins can view all records.
-		if(user.client.holder && isAdminObserver(user))
-			// Formatted output list of records.
-			var/admin_line = ""
+	if(linked_flavor && user.client.holder && isAdminObserver(user))
+		// Formatted output list of records.
+		var/admin_line = ""
 
-			if(linked_flavor.flavor_text)
-				admin_line += "<a href='?src=[REF(linked_flavor)];flavor_text=1'>\[FLA\]</a>"
-			if(linked_flavor.gen_records)
-				admin_line += "<a href='?src=[REF(linked_flavor)];general_records=1'>\[GEN\]</a>"
-			if(linked_flavor.sec_records)
-				admin_line += "<a href='?src=[REF(linked_flavor)];security_records=1'>\[SEC\]</a>"
-			if(linked_flavor.med_records)
-				admin_line += "<a href='?src=[REF(linked_flavor)];medical_records=1'>\[MED\]</a>"
-			if(linked_flavor.expl_info)
-				admin_line += "<a href='?src=[REF(linked_flavor)];exploitable_info=1'>\[EXP\]</a>"
+		if(linked_flavor.flavor_text)
+			admin_line += "<a href='?src=[REF(linked_flavor)];flavor_text=1'>\[FLA\]</a>"
+		if(linked_flavor.gen_records)
+			admin_line += "<a href='?src=[REF(linked_flavor)];general_records=1'>\[GEN\]</a>"
+		if(linked_flavor.sec_records)
+			admin_line += "<a href='?src=[REF(linked_flavor)];security_records=1'>\[SEC\]</a>"
+		if(linked_flavor.med_records)
+			admin_line += "<a href='?src=[REF(linked_flavor)];medical_records=1'>\[MED\]</a>"
+		if(linked_flavor.expl_info)
+			admin_line += "<a href='?src=[REF(linked_flavor)];exploitable_info=1'>\[EXP\]</a>"
 
-			if(admin_line)
-				expanded_examine += "ADMIN EXAMINE: [ADMIN_LOOKUPFLW(src)] - [admin_line]\n"
+		if(admin_line)
+			expanded_examine += "ADMIN EXAMINE: [ADMIN_LOOKUPFLW(src)] - [admin_line]\n"
 
 	// if the mob doesn't have a client, show how long they've been disconnected for.
 	if(!client && last_connection_time)

--- a/jollystation_modules/code/modules/mob/living/carbon/human/flavor_text.dm
+++ b/jollystation_modules/code/modules/mob/living/carbon/human/flavor_text.dm
@@ -3,20 +3,28 @@
 GLOBAL_LIST_EMPTY(flavor_texts)
 
 /*
- * Create a flavor text datum for [added_mob].
+ * Gets the mob's flavor text datum from the global associated lists of flavor texts.
+ * If no flavor text was found, create a new flavor text datum for [added_mob]
  *
- * Returns TRUE if successful, FALSE otherwise.
+ * Returns a datum instance - either a new flavor text or a flavor text from the global list
+ * Returns null if the mob was not living or something goes wrong
  */
-/proc/add_mob_flavor_text(mob/living/added_mob)
-	if(!istype(added_mob))
-		return FALSE
+/proc/add_or_get_mob_flavor_text(mob/living/added_mob)
+	RETURN_TYPE(/datum/flavor_text)
 
-	if(!GLOB.flavor_texts[added_mob.real_name])
-		var/datum/flavor_text/found_text = new /datum/flavor_text(added_mob)
+	if(!istype(added_mob))
+		return null
+
+	var/datum/flavor_text/found_text = GLOB.flavor_texts[added_mob.real_name]
+	if(!found_text)
+		found_text = new /datum/flavor_text(added_mob)
 		GLOB.flavor_texts[added_mob.real_name] = found_text
+		if(added_mob.linked_flavor)
+			stack_trace("We just made a new flavor text datum for [added_mob] even though it had flavor text linked already, something is messed up")
 		added_mob.linked_flavor = found_text
 
-	return TRUE
+	return found_text
+
 
 /// Flavor text define for carbons.
 /mob/living

--- a/jollystation_modules/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/jollystation_modules/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -10,41 +10,47 @@
  * returns null otherwise.
  */
 /mob/living/proc/get_visible_flavor(mob/examiner)
-	return null
+	RETURN_TYPE(/datum/flavor_text)
+
+	var/datum/flavor_text/found_flavor = linked_flavor
+	// Simple animals, basic animals, anything that's not a human/silicon is lumped under "simple"
+	if(found_flavor?.linked_species != "simple")
+		return null
+
+	return found_flavor
 
 /mob/living/carbon/human/get_visible_flavor(mob/examiner)
-	//var/face_obscured = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
-	var/shown_name = get_visible_name()
-
 	// your identity is always known to you
 	if(examiner == src)
 		return linked_flavor
 
+	var/shown_name = get_visible_name()
 	if(shown_name == "Unknown")
 		return null
 
+	var/datum/flavor_text/found_flavor
 	// the important check - if the visible name is our flavor text name, display our flavor text
 	// if the visible name is not, however, we may be in disguise - so grab the corresponding flavor text from our global list
 	if(shown_name == linked_flavor?.name || findtext(shown_name, linked_flavor?.name))
-		. = linked_flavor
+		found_flavor = linked_flavor
 	else
-		. = GLOB.flavor_texts[shown_name]
+		found_flavor = GLOB.flavor_texts[shown_name]
 
-	var/datum/flavor_text/found_flavor = .
-
-	// if you are not the species linked to the flavor text, you are not recognizable
+	// if you are not the species linked to the flavor text we found, you are not recognizable
 	if(found_flavor?.linked_species != dna?.species.id)
-		. = null
+		return null
+
+	return found_flavor
 
 /mob/living/silicon/get_visible_flavor(mob/examiner)
-	. = linked_flavor
-
 	if(examiner == src)
-		return
+		return linked_flavor
 
-	var/datum/flavor_text/found_flavor = .
+	var/datum/flavor_text/found_flavor = linked_flavor
 	if(found_flavor?.linked_species != "silicon")
-		. = null
+		return null
+
+	return found_flavor
 
 /mob/proc/check_med_hud_and_access()
 	return FALSE


### PR DESCRIPTION
- (Maybe?) Fixes loadouts not properly being migrated if your saved loadout list is form pre-datumized loadouts
- Sanitizes loadout list on save as well as load
- Split multiline preference up for future use
- Fixed a null runtime in flavor text prefs
- Refactored some flavor text code to be slightly cleaner