### PR TITLE
Adds a random event: Solar Flare

### DIFF
--- a/jollystation.dme
+++ b/jollystation.dme
@@ -4049,6 +4049,7 @@
 #include "jollystation_modules\code\modules\clothing\under\jobs\security.dm"
 #include "jollystation_modules\code\modules\events\resource_drift.dm"
 #include "jollystation_modules\code\modules\events\resource_pods.dm"
+#include "jollystation_modules\code\modules\events\solar_flare.dm"
 #include "jollystation_modules\code\modules\food_and_drinks\recipes\drinks_recipes.dm"
 #include "jollystation_modules\code\modules\hydroponics\hydroponics.dm"
 #include "jollystation_modules\code\modules\hydroponics\grown\beans.dm"

--- a/jollystation_modules/code/modules/events/solar_flare.dm
+++ b/jollystation_modules/code/modules/events/solar_flare.dm
@@ -33,7 +33,7 @@
 
 	picked_dept = pick(possible_choices)
 	impacted_areas = get_areas(picked_dept, possible_choices[picked_dept])
-	message_admins("A solar flare event is set to target the [picked_dept] department.")
+	message_admins("A solar flare event has triggered, targeting the [picked_dept] department.")
 
 /datum/round_event/solar_flare/announce(fake)
 	priority_announce("[command_name()] has issued an emergency solar weather warning for your station. The afflicted area has not yet been detected. Stay alert, report any sightings of activity, and evacuate affected departments.", "Solar Weather Alert")

--- a/jollystation_modules/code/modules/events/solar_flare.dm
+++ b/jollystation_modules/code/modules/events/solar_flare.dm
@@ -10,16 +10,19 @@
 /datum/round_event/solar_flare
 	announceWhen = 5
 
+	/// Whether the event was announced or hidden
+	var/was_announced = TRUE
 	/// Time (in seconds) between flares.
-	var/time_between_flares = 4
+	var/time_between_flares = 5
 	/// Department string picked.
 	var/picked_dept
 	/// List of areas valid.
 	var/list/area/impacted_areas
 
 /datum/round_event/solar_flare/setup()
-	startWhen = rand(20, 50)
-	endWhen = startWhen + 120
+	startWhen = rand(45, 90) // 1 == 1 second.
+	endWhen = startWhen + rand(90, 150)
+	time_between_flares += rand(-1, 1)
 
 	var/static/list/possible_choices = list(
 		DEPARTMENT_SECURITY = /area/security,
@@ -36,13 +39,18 @@
 	message_admins("A solar flare event has triggered, targeting the [picked_dept] department.")
 
 /datum/round_event/solar_flare/announce(fake)
+	was_announced = (!fake && TRUE)
 	priority_announce("[command_name()] has issued an emergency solar weather warning for your station. The afflicted area has not yet been detected. Stay alert, report any sightings of activity, and evacuate affected departments.", "Solar Weather Alert")
 
-/datum/round_event/solar_flare/end()
-	priority_announce("[command_name()] has issued an all clear signal for your station. The solar weather event over [picked_dept] has cleared. Please return to your workplaces and resume duty.", "All Clear Alert")
-
 /datum/round_event/solar_flare/start()
+	if(was_announced)
+		var/detected_location = prob(30) // 30% chance that the event will reveal the location when it starts
+		priority_announce("A solar weather event is ocurring over [detected_location ? "the [picked_dept]" : "an undetected"] department. [detected_location ? "" : "All crew are to locate and report the afflicted area. "]Evacuate all personnel and personal belongings from affected rooms until the weather has cleared.", "Solar Weather Alert")
 	deadchat_broadcast("A <b>Solar Flare</b> event has triggered, targeting the [picked_dept] department.", message_type = DEADCHAT_ANNOUNCEMENT)
+
+/datum/round_event/solar_flare/end()
+	if(was_announced)
+		priority_announce("[command_name()] has issued an all clear signal for your station. The solar weather event over the [picked_dept] department has cleared. Please return to your workplaces and resume duty.", "All Clear Alert")
 
 /datum/round_event/solar_flare/tick()
 	if(activeFor % time_between_flares != 0)
@@ -59,11 +67,18 @@
  */
 /datum/round_event/solar_flare/proc/trigger_flare(area/chosen_area)
 	var/turf/destination = get_valid_turf_from_area(chosen_area)
-	if(isturf(destination))
-		if(prob(90))
-			new /obj/effect/solar_flare(destination, TRUE)
-		else
-			new /obj/effect/solar_flare/large(destination, TRUE)
+	if(!isturf(destination))
+		return
+
+	// Weight of picking each type of flare. Adds up to 100 for easy math.
+	var/static/list/flare_types_to_weight = list(
+		/obj/effect/solar_flare = 88,
+		/obj/effect/solar_flare/large = 8,
+		/obj/effect/solar_flare/emp = 4,
+	)
+
+	var/obj/effect/solar_flare/spawned_flare = pickweight(flare_types_to_weight)
+	new spawned_flare(destination, TRUE)
 
 /*
  * Get a random non-dense turf of all the turfs in [chosen_area].
@@ -138,9 +153,6 @@
 	/// List of turfs/mobs/whatever we already hit with the flare
 	var/list/already_heated_things
 
-/obj/effect/solar_flare/large
-	radius = 4
-
 /obj/effect/solar_flare/Initialize(mapload, admin_spawned = FALSE)
 	. = ..()
 	if(!isturf(loc))
@@ -160,30 +172,41 @@
 	return ..()
 
 /obj/effect/solar_flare/process(delta_time)
-	if(curr_radius++ > radius)
-		qdel(src)
-		return
-
 	for(var/select_turf in turfs_to_heat)
 		do_flare(select_turf)
 
 		for(var/side_turf in get_adjacent_open_turfs(select_turf))
 			if(side_turf in already_heated_things)
 				continue
-			turfs_to_heat += side_turf
+			turfs_to_heat |= side_turf
 
 		turfs_to_heat -= select_turf
 
+	if(++curr_radius > radius)
+		qdel(src)
 
 /obj/effect/solar_flare/proc/do_flare(turf/location)
 	new /obj/effect/hotspot(location)
 
-	location.hotspot_expose(1000, 250, 1)
+	location.hotspot_expose(clamp((1000 - curr_radius * 100), 500, 1000), clamp((250 - curr_radius * 25), 100, 250), 1)
 	LAZYADD(already_heated_things, location)
 	for(var/mob/living/hit_mob in location.contents)
 		if(hit_mob in already_heated_things)
 			continue
 		LAZYADD(already_heated_things, hit_mob)
 		hit_mob.apply_damage((clamp((radius - curr_radius), 0.5, 3) * 30), BURN, spread_damage = TRUE)
-		hit_mob.adjust_fire_stacks(3)
+		hit_mob.adjust_fire_stacks(clamp(radius - curr_radius, 1, 5))
 		hit_mob.IgniteMob()
+
+// Larger flare. Double radius.
+/obj/effect/solar_flare/large
+	radius = 4
+
+// Slightly larger flare, comes with added EMP action, but much rarer
+// Heaviest area of the EMP are in the very center of the flare
+/obj/effect/solar_flare/emp
+	radius = 3
+
+/obj/effect/solar_flare/emp/do_flare(turf/location)
+	. = ..()
+	empulse(location, round(radius / 3), radius)

--- a/jollystation_modules/code/modules/events/solar_flare.dm
+++ b/jollystation_modules/code/modules/events/solar_flare.dm
@@ -1,0 +1,189 @@
+/// -- Solar flare event. spawns fire in a department. --
+/datum/round_event_control/solar_flare
+	name = "Solar Flare"
+	typepath = /datum/round_event/solar_flare
+
+	weight = 10
+	max_occurrences = 1
+	earliest_start = 20 MINUTES
+
+/datum/round_event/solar_flare
+	announceWhen = 5
+
+	/// Time (in seconds) between flares.
+	var/time_between_flares = 4
+	/// Department string picked.
+	var/picked_dept
+	/// List of areas valid.
+	var/list/area/impacted_areas
+
+/datum/round_event/solar_flare/setup()
+	startWhen = rand(20, 50)
+	endWhen = startWhen + 120
+
+	var/static/list/possible_choices = list(
+		DEPARTMENT_SECURITY = /area/security,
+		DEPARTMENT_COMMAND = /area/command,
+		DEPARTMENT_SERVICE = /area/service,
+		DEPARTMENT_SCIENCE = /area/science,
+		DEPARTMENT_ENGINEERING = /area/engineering,
+		DEPARTMENT_MEDICAL = /area/medical,
+		DEPARTMENT_CARGO = /area/cargo,
+	)
+
+	picked_dept = pick(possible_choices)
+	impacted_areas = get_areas(picked_dept, possible_choices[picked_dept])
+	message_admins("A solar flare event is set to target the [picked_dept] department.")
+
+/datum/round_event/solar_flare/announce(fake)
+	priority_announce("[command_name()] has issued an emergency solar weather warning for your station. The afflicted area has not yet been detected. Stay alert, report any sightings of activity, and evacuate affected departments.", "Solar Weather Alert")
+
+/datum/round_event/solar_flare/end()
+	priority_announce("[command_name()] has issued an all clear signal for your station. The solar weather event over [picked_dept] has cleared. Please return to your workplaces and resume duty.", "All Clear Alert")
+
+/datum/round_event/solar_flare/start()
+	deadchat_broadcast("A <b>Solar Flare</b> event has triggered, targeting the [picked_dept] department.", message_type = DEADCHAT_ANNOUNCEMENT)
+
+/datum/round_event/solar_flare/tick()
+	if(activeFor % time_between_flares != 0)
+		return
+
+	var/list/our_areas = LAZYCOPY(impacted_areas)
+	for(var/i in 0 to rand(2, 4))
+		if(!LAZYLEN(our_areas))
+			return
+		addtimer(CALLBACK(src, .proc/trigger_flare, pick_n_take(our_areas)), i SECONDS)
+
+/*
+ * Trigger a solar flare effect at a random non-dense turf in [chosen_area].
+ */
+/datum/round_event/solar_flare/proc/trigger_flare(area/chosen_area)
+	var/turf/destination = get_valid_turf_from_area(chosen_area)
+	if(isturf(destination))
+		if(prob(90))
+			new /obj/effect/solar_flare(destination, TRUE)
+		else
+			new /obj/effect/solar_flare/large(destination, TRUE)
+
+/*
+ * Get a random non-dense turf of all the turfs in [chosen_area].
+ */
+/datum/round_event/solar_flare/proc/get_valid_turf_from_area(area/chosen_area)
+	RETURN_TYPE(/turf)
+	var/list/turf/turfs = get_area_turfs(chosen_area)
+
+	if(!LAZYLEN(turfs))
+		return null
+
+	for(var/turf/a_turf as anything in turfs)
+		if(a_turf.density)
+			turfs -= a_turf
+
+	return pick(turfs)
+
+/*
+ * Get all areas associated with a department.
+ */
+/datum/round_event/solar_flare/proc/get_areas(department, area_path)
+	RETURN_TYPE(/list)
+	. = subtypesof(area_path)
+
+	// There's much more OOP ways to do this, but whatever
+	switch(department)
+		if(DEPARTMENT_SECURITY)
+			. -= typesof(/area/security/checkpoint)
+			. -= /area/security/detectives_office/bridge_officer_office
+
+		if(DEPARTMENT_COMMAND)
+			. -= /area/command/gateway
+			. += /area/security/detectives_office/bridge_officer_office
+
+		if(DEPARTMENT_SERVICE)
+			. -= /area/service/electronic_marketing_den
+			. -= /area/service/abandoned_gambling_den
+			. -= /area/service/abandoned_gambling_den/secondary
+			. -= /area/service/theater/abandoned
+			. -= /area/service/library/abandoned
+			. -= /area/service/hydroponics/garden/abandoned
+
+		if(DEPARTMENT_CARGO)
+			. += /area/security/checkpoint/supply
+
+		if(DEPARTMENT_ENGINEERING)
+			. -= /area/engineering/supermatter
+			. -= /area/engineering/supermatter/room
+			. -= /area/engineering/gravity_generator
+			. += /area/security/checkpoint/engineering
+
+		if(DEPARTMENT_SCIENCE)
+			. -= /area/science/research/abandoned
+			. += /area/security/checkpoint/science
+			. += /area/security/checkpoint/science/research
+
+		if(DEPARTMENT_MEDICAL)
+			. -= /area/medical/abandoned
+			. += /area/security/checkpoint/medical
+
+// Solar flare. Causes a diamond of fire centered on the initial turf.
+/obj/effect/solar_flare
+	anchored = TRUE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+	/// Max radius of the flare
+	var/radius = 2
+	/// Current radius we're at
+	var/curr_radius = 0
+	/// List of turfs we've yet to expose with the flare (via process)
+	var/list/turf/turfs_to_heat
+	/// List of turfs/mobs/whatever we already hit with the flare
+	var/list/already_heated_things
+
+/obj/effect/solar_flare/large
+	radius = 4
+
+/obj/effect/solar_flare/Initialize(mapload, admin_spawned = FALSE)
+	. = ..()
+	if(!isturf(loc))
+		stack_trace("Solar flare initialized in a non-turf loc, what?")
+		return INITIALIZE_HINT_QDEL
+
+	turfs_to_heat = list(loc)
+	START_PROCESSING(SSfastprocess, src)
+	playsound(loc, 'sound/magic/fireball.ogg', 60, TRUE)
+	if(!admin_spawned)
+		message_admins("Solar flare triggered at [ADMIN_VERBOSEJMP(loc)].")
+
+/obj/effect/solar_flare/Destroy(force)
+	LAZYCLEARLIST(turfs_to_heat)
+	LAZYCLEARLIST(already_heated_things)
+	STOP_PROCESSING(SSfastprocess, src)
+	return ..()
+
+/obj/effect/solar_flare/process(delta_time)
+	if(curr_radius++ > radius)
+		qdel(src)
+		return
+
+	for(var/select_turf in turfs_to_heat)
+		do_flare(select_turf)
+
+		for(var/side_turf in get_adjacent_open_turfs(select_turf))
+			if(side_turf in already_heated_things)
+				continue
+			turfs_to_heat += side_turf
+
+		turfs_to_heat -= select_turf
+
+
+/obj/effect/solar_flare/proc/do_flare(turf/location)
+	new /obj/effect/hotspot(location)
+
+	location.hotspot_expose(1000, 250, 1)
+	LAZYADD(already_heated_things, location)
+	for(var/mob/living/hit_mob in location.contents)
+		if(hit_mob in already_heated_things)
+			continue
+		LAZYADD(already_heated_things, hit_mob)
+		hit_mob.apply_damage((clamp((radius - curr_radius), 0.5, 3) * 30), BURN, spread_damage = TRUE)
+		hit_mob.adjust_fire_stacks(3)
+		hit_mob.IgniteMob()


### PR DESCRIPTION
Adds a random event, titled "Solar Flare" to the game. 

This random event causes multiple "fireballs" to pop up everywhere around a department for the duration of the event. These fireballs are 2-4 radius diamonds of fire that deal moderate damage to mobs on the tile and of course set fire to anything around. 

- The event as uncommon, about as rare as a radiation storm.
- It can only occur once per shift without admin intervention.
- Once triggered, it will randomly begin sometime in the next 45 to 90 seconds.
- Once began, it will last somewhere between 90 and 150 seconds.
- There's a 30% chance the event will tell the crew where the solar flares are occurring. Otherwise, it will be unknown.
- A solar flare will trigger every 4 to 6 seconds.
- When a solar flare triggers, it will spawn a solar flare on 3 to 5 turfs in the target department. 
   - 88% of the flares will be standard 2 radius. They deal 60 damage if you're dead center, 30 damage adjacent, 15 on the rim.
   - 8% of the flares will be expanded 4 radius. They deal 90 damage if you're dead center, then 60, 30, 15. 
   - 4% of the flares will have 3 radius and come with an EMP. Heavy range encompasses only the dead center, light range encompasses the radius of the flare.

The goal of this PR is to add more environmental events to offset the lack of action. Gives medbay something to do and gives the crew something to worry about. Kinda like meteors but not roundending. 

![image](https://user-images.githubusercontent.com/51863163/140176954-be330ce4-6738-48f6-9e73-4d67ab1413b1.png)

